### PR TITLE
Create haystack-commons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 .node_modules
 deployment/k8s/third_party_softwares/*
+*.iml

--- a/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
+++ b/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
@@ -88,7 +88,7 @@ data:
       separator = "."
       udp-read-buffer = 0
       templates = [
-       "haystack.* system.server.subsystem.class.measurement*",
+       "haystack.* system.subsystem.server.class.measurement*",
       ]
 
     [[collectd]]

--- a/haystack-commons/README.md
+++ b/haystack-commons/README.md
@@ -1,0 +1,133 @@
+# Haystack-commons
+This haystack-commons module contains code needed by most or all of the other modules in the Haystack code base.
+
+## Metrics
+The Haystack system is deployed by [Kubernetes](https://en.wikipedia.org/wiki/Kubernetes) and comes with an
+[InfluxDb](https://www.influxdata.com/time-series-platform/influxdb/) database for time series data (TSD).
+Other modules then use Netflix [Servo](https://github.com/Netflix/servo) metrics objects to create two types of metrics:
+1. [Counter](https://github.com/Netflix/servo/blob/master/servo-core/src/main/java/com/netflix/servo/monitor/Counter.java)
+monitors to track how often an event of interest is occurring, and
+2. [Timer](https://github.com/Netflix/servo/blob/master/servo-core/src/main/java/com/netflix/servo/monitor/Timer.java)
+monitors to track how much time an event of interest is taking.
+
+Glue code in the [metrics](src/main/java/com/expedia/www/haystack/metrics) package of this module makes it easy to 
+create Counters and Timers.
+### Usage
+#### Dependencies
+In the `<properties>` section of pom.xml put:
+```
+<servo-version>...</servo-version>
+<haystack-commons-version>...</haystack-commons-version>
+```
+You should of course use the correct version of the dependencies in place of ... above.
+
+In the `<dependencies>` section of pom.xml put:
+```
+<!-- https://mvnrepository.com/artifact/com.netflix.servo/servo-core -->
+<dependency>
+    <groupId>com.netflix.servo</groupId>
+    <artifactId>servo-core</artifactId>
+    <version>${servo-version}</version>
+</dependency>
+<!-- https://mvnrepository.com/artifact/com.netflix.servo/servo-graphite -->
+<dependency>
+    <groupId>com.netflix.servo</groupId>
+    <artifactId>servo-graphite</artifactId>
+    <version>${servo-version}</version>
+</dependency>
+<dependency>
+    <groupId>com.expedia.www</groupId>
+    <artifactId>haystack-commons</artifactId>
+    <version>${haystack-commons-version}</version>
+</dependency>
+```
+#### How to create objects
+##### Subsystem
+As you will see, creating a Servo object in Haystack requires a "subsystem" String, whose value will be something like
+"pipes" or "trends"; the `SUBSYSTEM` constant below should be defined at a high level in your subsystem code base.
+```
+public static final String SUBSYSTEM = "subsystemName"; // e.g. "pipes" or "trends"
+```
+##### Class
+Creating a Servo object also requires a "class" String, which is often the Java class or Scala object containing the
+object:
+```
+private static final String CLASS_NAME = ClassContainingTheCounter.class.getSimpleName();
+```
+Refactoring or renaming may well lead to changing the name of the Java class or Scala object in which the Servo object
+resides, so it also acceptable to choose a "class" String that will never change:
+```
+private static final String CLASS_NAME = "JsonSerialization";
+```
+The class never should not contain spaces or periods; if it does, they will be changed to a hyphen.
+##### Singleton
+Your Servo objects should be singletons, either as static (Java) or object (Scala) variables. 
+#### Counter
+The code below is a Java snippet that shows the right way to create a Counter:
+```
+static final Counter REQUEST = MetricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS_NAME, "REQUEST");
+```
+Because the Servo Counter generates a RATE metric, using upper case for the variable name `REQUEST` and the counter name 
+`"REQUEST"` is recommended because doing so results in an sensibly named complete metric name of `REQUEST_RATE` in
+InfluxDb, as explained in the "Graphite Bridge" section of this document.
+#### Timer
+The code below is a Java snippet that shows the right way to create a Timer:
+```
+static final Timer JSON_SERIALIZATION = MetricObjects.createAndRegisterTimer(SUBSYSTEM, KLASS_NAME, "JSON_SERIALIZATION", TimeUnit.MICROSECONDS);
+```
+The Servo Timer generates two metrics (GAUGE and NORMALIZED), and using upper case is again suggested (see the Counter 
+section above) to create complete metric names of `JSON_SERIALIZATION_GAUGE` and `JSON_SERIALIZATION_NORMALIZED`.
+Choose the appropriate time unit as the last argument:
+* For on-host code, `TimeUnit.MICROSECONDS` is probably appropriate
+* For network calls, `TimeUnit.MILLISECONDS` may be sufficient.
+#### The Main Method
+To initialize the metrics system, the first line of your main() method should be:
+```
+MetricPublishing.start();
+```
+#### Configuration
+You will typically have a base.yaml in your resources directory whose contents will include:
+```
+haystack:
+  graphite:
+     prefix: "haystack"
+     address: "haystack.local" # set in /etc/hosts per instructions in haystack/deployment module
+     port: 2003 # Graphite port; typicallly 2003
+     pollIntervalSeconds: 60
+     queueSize: 10
+```
+### Graphite Bridge
+The Graphite [plaintext protocol](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
+consists of three space-delimited Strings terminated by a newline:
+```
+ <metric path> <metric value> <metric timestamp>\n
+```
+The `<metric value>` is a number, and the pieces of `<metric path>` are traditionally separated by a period.
+Note that the period-delimited pieces contain no metadata; that is, the meanings of each piece are not specified in the
+message. This lack of metadata is addressed in [OpenTSDB](http://opentsdb.net) but a bridge to connect Servo metrics to
+InfluxDb via the OpenTSDB protocol does not currently exist; instead, the bridge uses the Graphite plaintext protocol, 
+and an InfluxDb template (read about them in this 
+[README](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) file) parses the Graphite plain
+text message into tags. (You can read about metrics tags 
+[here](http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html)).)
+
+This graphite bridge therefore requires a convention to map each metric piece to a tag; this convention is found/used in 
+three places that must agree on the convention:
+1. The template configuration (see the `templates` value in 
+[influxdb.yaml](../deployment/k8s/addons/1.6/monitoring/influxdb.yaml))
+2. The code that builds client-side tags (see `getTags()` in 
+[MetricObjects.java](src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java))
+3. The code that creates the graphite plain text message from the metric and its client-side tags (see `getName()` in 
+[HaystackGraphiteNamingConvention.java](src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java))
+
+As a result, the graphite message has the following meaning:
+```
+<system>.<server>.<subsystem>.<class>.<VARIABLE_NAME>_<METRIC_NAME>
+```
+where:
+* `<system>` is always "haystack"
+* `<server>` is the host name
+* `<subsystem>` is the value discussed in the "Subsystem" section above
+* `<class>` is the  value discussed in the "Class" section above
+* `<VARIABLE_NAME>_<METRIC_NAME>` is the complete metric name; see `REQUEST_RATE`, `JSON_SERIALIZATION_GAUGE`, and 
+`JSON_SERIALIZATION_NORMALIZED` in the "Counter" and "Timer" sections above.

--- a/haystack-commons/README.md
+++ b/haystack-commons/README.md
@@ -42,6 +42,7 @@ As you will see, creating a Servo object in Haystack requires a "subsystem" Stri
 ```
 public static final String SUBSYSTEM = "subsystemName"; // e.g. "pipes" or "trends"
 ```
+`SUBSYSTEM` never should not contain spaces or periods; if it does, each will be changed to a hyphen.
 ##### Class
 Creating a Servo object also requires a "class" String, which is often the Java class or Scala object containing the
 object:
@@ -53,7 +54,7 @@ resides, so it also acceptable to choose a "class" String that will never change
 ```
 private static final String CLASS_NAME = "JsonSerialization";
 ```
-The class never should not contain spaces or periods; if it does, they will be changed to a hyphen.
+`CLASS_NAME` never should not contain spaces or periods; if it does, each will be changed to a hyphen.
 ##### Singleton
 Your Servo objects should be singletons, either as static (Java) or object (Scala) variables. 
 #### Counter
@@ -109,7 +110,7 @@ haystack:
   graphite:
      prefix: "haystack"
      address: "haystack.local" # set in /etc/hosts per instructions in haystack/deployment module
-     port: 2003 # Graphite port; typicallly 2003
+     port: 2003 # Graphite port; typically 2003
      pollIntervalSeconds: 60
      queueSize: 10
 ```
@@ -126,7 +127,7 @@ InfluxDb via the OpenTSDB protocol does not currently exist; instead, the bridge
 and an InfluxDb template (read about them in this 
 [README](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) file) parses the Graphite plain
 text message into tags. (You can read about metrics tags 
-[here](http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html)).)
+[here](http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html).))
 
 This graphite bridge therefore requires a convention to map each metric piece to a tag; this convention is found/used in 
 three places that must agree on the convention:

--- a/haystack-commons/pom.xml
+++ b/haystack-commons/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.expedia.www</groupId>
+    <artifactId>haystack-commons</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>haystack-commons</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <cfg4j-core-version>4.4.1</cfg4j-core-version>
+        <junit-version>4.12</junit-version>
+        <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
+        <maven-jar-plugin-version>3.0.2</maven-jar-plugin-version>
+        <mockito-version>1.9.5</mockito-version>
+        <servo-version>0.12.17</servo-version>
+        <slf4j-version>1.7.25</slf4j-version>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.cfg4j/cfg4j-core -->
+        <dependency>
+            <groupId>org.cfg4j</groupId>
+            <artifactId>cfg4j-core</artifactId>
+            <version>${cfg4j-core-version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.netflix.servo/servo-core -->
+        <dependency>
+            <groupId>com.netflix.servo</groupId>
+            <artifactId>servo-core</artifactId>
+            <version>${servo-version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.netflix.servo/servo-graphite -->
+        <dependency>
+            <groupId>com.netflix.servo</groupId>
+            <artifactId>servo-graphite</artifactId>
+            <version>${servo-version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Build an executable JAR -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin-version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/haystack-commons/pom.xml
+++ b/haystack-commons/pom.xml
@@ -3,7 +3,25 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    <!--
+       /*
+        *
+        *  Copyright 2017 Expedia, Inc.
+        *
+        *     Licensed under the Apache License, Version 2.0 (the "License");
+        *     you may not use this file except in compliance with the License.
+        *     You may obtain a copy of the License at
+        *
+        *         http://www.apache.org/licenses/LICENSE-2.0
+        *
+        *     Unless required by applicable law or agreed to in writing, software
+        *     distributed under the License is distributed on an "AS IS" BASIS,
+        *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        *     See the License for the specific language governing permissions and
+        *     limitations under the License.
+        *
+        */
+      -->
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-commons</artifactId>
     <version>1.0-SNAPSHOT</version>

--- a/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/GraphiteConfig.java
+++ b/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/GraphiteConfig.java
@@ -1,0 +1,11 @@
+package com.expedia.www.haystack.metrics;
+
+public interface GraphiteConfig {
+    String address();
+
+    int port();
+
+    int pollIntervalSeconds();
+
+    int queueSize();
+}

--- a/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java
+++ b/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java
@@ -1,0 +1,67 @@
+package com.expedia.www.haystack.metrics;
+
+import com.netflix.servo.Metric;
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.servo.publish.graphite.GraphiteNamingConvention;
+import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.TagList;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_CLASS;
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
+
+public class HaystackGraphiteNamingConvention implements GraphiteNamingConvention {
+    static final String HOST_NAME_UNKNOWN_HOST_EXCEPTION = "HostName-UnknownHostException";
+    static final String MISSING_TAG = "MISSING_TAG_%s";
+    static final String MISSING_VALUE = "MISSING_VALUE_%s";
+    static final String METRIC_FORMAT = "%s.%s.%s.%s_%s";
+
+    static Factory factory = new Factory(); // will be mocked out in unit tests
+    static final String LOCAL_HOST_NAME = getLocalHost();
+
+    static String getLocalHost() {
+        try {
+            return cleanup(factory.getLocalHost().getHostName(), "");
+        } catch (UnknownHostException e) {
+            return HOST_NAME_UNKNOWN_HOST_EXCEPTION;
+        }
+    }
+
+    @Override
+    public String getName(Metric metric) {
+        final MonitorConfig config = metric.getConfig();
+        final TagList tags = config.getTags();
+        final String subsystem = cleanup(tags, TAG_KEY_SUBSYSTEM);
+        final String klass = cleanup(tags, TAG_KEY_CLASS);
+        final String configName = config.getName(); // Servo disallows null for name, no need to cleanup
+        final String type = cleanup(tags, DataSourceType.KEY);
+        return String.format(METRIC_FORMAT, LOCAL_HOST_NAME, subsystem, klass, configName, type);
+    }
+
+    private static String cleanup(TagList tags, String name) {
+        return cleanup(tags.getTag(name), name);
+    }
+
+    private static String cleanup(Tag tag, String name) {
+        if(tag == null) {
+            return String.format(MISSING_TAG, name);
+        }
+        return cleanup(tag.getValue(), name);
+    }
+
+    private static String cleanup(String value, String name) {
+        if(value == null) {
+            return String.format(MISSING_VALUE, name);
+        }
+        return value.replace(" ", "_").replace(".", "_");
+    }
+
+    static class Factory {
+        InetAddress getLocalHost() throws UnknownHostException {
+            return InetAddress.getLocalHost();
+        }
+    }
+}

--- a/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java
+++ b/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java
@@ -38,7 +38,7 @@ public class HaystackGraphiteNamingConvention implements GraphiteNamingConventio
         final String klass = cleanup(tags, TAG_KEY_CLASS);
         final String configName = config.getName(); // Servo disallows null for name, no need to cleanup
         final String type = cleanup(tags, DataSourceType.KEY);
-        return String.format(METRIC_FORMAT, LOCAL_HOST_NAME, subsystem, klass, configName, type);
+        return String.format(METRIC_FORMAT, subsystem, LOCAL_HOST_NAME, klass, configName, type);
     }
 
     private static String cleanup(TagList tags, String name) {

--- a/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
+++ b/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
@@ -20,7 +20,16 @@ import java.util.concurrent.TimeUnit;
 public class MetricObjects {
     static final String TAG_KEY_SUBSYSTEM = "subsystem";
     static final String TAG_KEY_CLASS = "class";
-    static Factory factory = new Factory(); // will be mocked out in unit tests
+
+    private final Factory factory;
+
+    public MetricObjects() {
+        this(new Factory());
+    }
+
+    public MetricObjects(Factory factory) {
+        this.factory = factory;
+    }
 
     /**
      * Creates a new Counter; you should only call this method once for each Counter in your code.
@@ -30,7 +39,7 @@ public class MetricObjects {
      * @param counterName the name of the counter, usually the name of the variable holding the Counter instance
      * @return a new Counter that this method registers in the DefaultMonitorRegistry before returning it.
      */
-    public static Counter createAndRegisterCounter(String subsystem, String klass, String counterName) {
+    public Counter createAndRegisterCounter(String subsystem, String klass, String counterName) {
         final TaggingContext taggingContext = () -> getTags(subsystem, klass);
         final Counter counter = Monitors.newCounter(counterName, taggingContext);
         factory.getMonitorRegistry().register(counter);
@@ -46,7 +55,7 @@ public class MetricObjects {
      * @param timeUnit  desired precision, typically TimeUnit.MILLISECONDS
      * @return a new Timer that this method registers in the DefaultMonitorRegistry before returning it.
      */
-    public static Timer createAndRegisterTimer(String subsystem, String klass, String timerName, TimeUnit timeUnit) {
+    public Timer createAndRegisterTimer(String subsystem, String klass, String timerName, TimeUnit timeUnit) {
         final TaggingContext taggingContext = () -> getTags(subsystem, klass);
         final Timer timer = Monitors.newTimer(timerName, timeUnit, taggingContext);
         factory.getMonitorRegistry().register(timer);

--- a/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
+++ b/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
@@ -1,0 +1,69 @@
+package com.expedia.www.haystack.metrics;
+
+import com.netflix.servo.DefaultMonitorRegistry;
+import com.netflix.servo.MonitorRegistry;
+import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.Monitors;
+import com.netflix.servo.monitor.Timer;
+import com.netflix.servo.tag.BasicTagList;
+import com.netflix.servo.tag.SmallTagMap;
+import com.netflix.servo.tag.TagList;
+import com.netflix.servo.tag.TaggingContext;
+import com.netflix.servo.tag.Tags;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Creates Servo's Counter and Timer objects, registering them with the default monitor registry when creating them.
+ */
+@SuppressWarnings("WeakerAccess")
+public class MetricObjects {
+    static final String TAG_KEY_SUBSYSTEM = "subsystem";
+    static final String TAG_KEY_CLASS = "class";
+    static Factory factory = new Factory(); // will be mocked out in unit tests
+
+    /**
+     * Creates a new Counter; you should only call this method once for each Counter in your code.
+     *
+     * @param subsystem   the subsystem, typically something like "pipes" or "trends"
+     * @param klass       the metric class, frequently (but not necessarily) the class containing the counter the module
+     * @param counterName the name of the counter, usually the name of the variable holding the Counter instance
+     * @return a new Counter that this method registers in the DefaultMonitorRegistry before returning it.
+     */
+    public static Counter createAndRegisterCounter(String subsystem, String klass, String counterName) {
+        final TaggingContext taggingContext = () -> getTags(subsystem, klass);
+        final Counter counter = Monitors.newCounter(counterName, taggingContext);
+        factory.getMonitorRegistry().register(counter);
+        return counter;
+    }
+
+    /**
+     * Creates a new Timer; you should only call this method once for each Timer in your code
+     *
+     * @param subsystem the subsystem, typically something like "pipes" or "trends"
+     * @param klass     the metric class, frequently (but not necessarily) the class containing the counter the module
+     * @param timerName the name of the timer, usually the name of the variable holding the Timer instance
+     * @param timeUnit  desired precision, typically TimeUnit.MILLISECONDS
+     * @return a new Timer that this method registers in the DefaultMonitorRegistry before returning it.
+     */
+    public static Timer createAndRegisterTimer(String subsystem, String klass, String timerName, TimeUnit timeUnit) {
+        final TaggingContext taggingContext = () -> getTags(subsystem, klass);
+        final Timer timer = Monitors.newTimer(timerName, timeUnit, taggingContext);
+        factory.getMonitorRegistry().register(timer);
+        return timer;
+    }
+
+    private static TagList getTags(String subsystem, String klass) {
+        final SmallTagMap.Builder builder = new SmallTagMap.Builder(2);
+        builder.add(Tags.newTag(TAG_KEY_SUBSYSTEM, subsystem));
+        builder.add(Tags.newTag(TAG_KEY_CLASS, klass));
+        return new BasicTagList(builder.result());
+    }
+
+    static class Factory {
+        MonitorRegistry getMonitorRegistry() {
+            return DefaultMonitorRegistry.getInstance();
+        }
+    }
+}
+

--- a/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
+++ b/haystack-commons/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
@@ -1,0 +1,89 @@
+package com.expedia.www.haystack.metrics;
+
+import com.netflix.servo.publish.AsyncMetricObserver;
+import com.netflix.servo.publish.BasicMetricFilter;
+import com.netflix.servo.publish.CounterToRateMetricTransform;
+import com.netflix.servo.publish.MetricObserver;
+import com.netflix.servo.publish.MetricPoller;
+import com.netflix.servo.publish.MonitorRegistryMetricPoller;
+import com.netflix.servo.publish.PollRunnable;
+import com.netflix.servo.publish.PollScheduler;
+import com.netflix.servo.publish.graphite.GraphiteMetricObserver;
+import org.cfg4j.provider.ConfigurationProvider;
+import org.cfg4j.provider.ConfigurationProviderBuilder;
+import org.cfg4j.source.classpath.ClasspathConfigurationSource;
+import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
+
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Publishes metrics to InfluxDb on a regular interval. The frequency of publishing is controlled by configuration.
+ * Each application that uses this class must call MetricPublishing.start() in its main() method.
+ */
+@SuppressWarnings("WeakerAccess")
+public class MetricPublishing {
+    static final String ASYNC_METRIC_OBSERVER_NAME = "haystack";
+    static final int POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER = 2000;
+    static final int POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER = 2;
+
+    // TODO Add EnvironmentVariablesConfigurationSource object to handle env variables from apply-compose.sh et al
+    private static ConfigFilesProvider cfp = () -> Collections.singletonList(Paths.get("base.yaml"));
+    private static ClasspathConfigurationSource ccs = new ClasspathConfigurationSource(cfp);
+    private static ConfigurationProvider cp = new ConfigurationProviderBuilder().withConfigurationSource(ccs).build();
+
+    // will be mocked out in unit tests
+    static GraphiteConfig graphiteConfig = cp.bind("haystack.graphite", GraphiteConfig.class);
+    static Factory factory = new Factory();
+
+    public static void start() {
+        final PollScheduler pollScheduler = PollScheduler.getInstance();
+        pollScheduler.start();
+        final MetricPoller monitorRegistryMetricPoller = factory.createMonitorRegistryMetricPoller();
+        final List<MetricObserver> observers = Collections.singletonList(createGraphiteObserver());
+        final PollRunnable task = factory.createTask(monitorRegistryMetricPoller, observers);
+        pollScheduler.addPoller(task, graphiteConfig.pollIntervalSeconds(), TimeUnit.SECONDS);
+    }
+
+    static MetricObserver createGraphiteObserver() {
+        final String address = graphiteConfig.address() + ":" + graphiteConfig.port();
+        return rateTransform(async(factory.createGraphiteMetricObserver(ASYNC_METRIC_OBSERVER_NAME, address)));
+    }
+
+    static MetricObserver rateTransform(MetricObserver observer) {
+        final long heartbeat = POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER * graphiteConfig.pollIntervalSeconds();
+        return factory.createCounterToRateMetricTransform(observer, heartbeat, TimeUnit.SECONDS);
+    }
+
+    static MetricObserver async(MetricObserver observer) {
+        final long expireTime = POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER * graphiteConfig.pollIntervalSeconds();
+        final int queueSize = graphiteConfig.queueSize();
+        return factory.createAsyncMetricObserver(observer, queueSize, expireTime);
+    }
+
+    static class Factory {
+        MetricObserver createAsyncMetricObserver(MetricObserver observer, int queueSize, long expireTime) {
+            return new AsyncMetricObserver(ASYNC_METRIC_OBSERVER_NAME, observer, queueSize, expireTime);
+        }
+
+        MetricObserver createCounterToRateMetricTransform(
+                MetricObserver observer, long heartbeat, TimeUnit timeUnit) {
+            return new CounterToRateMetricTransform(observer, heartbeat, timeUnit);
+        }
+
+        MetricObserver createGraphiteMetricObserver(String prefix, String address) {
+            return new GraphiteMetricObserver(prefix, address, new HaystackGraphiteNamingConvention());
+        }
+
+        PollRunnable createTask(MetricPoller poller, Collection<MetricObserver> observers) {
+            return new PollRunnable(poller, BasicMetricFilter.MATCH_ALL, true, observers);
+        }
+
+        MetricPoller createMonitorRegistryMetricPoller() {
+            return new MonitorRegistryMetricPoller();
+        }
+    }
+}

--- a/haystack-commons/src/main/resources/base.yaml
+++ b/haystack-commons/src/main/resources/base.yaml
@@ -1,7 +1,7 @@
 haystack:
   graphite:
      prefix: "haystack"
-     address: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+     address: "haystack.local" # set in /etc/hosts per instructions in haystack/deployment module
      port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
      pollIntervalSeconds: 60
      queueSize: 10

--- a/haystack-commons/src/main/resources/base.yaml
+++ b/haystack-commons/src/main/resources/base.yaml
@@ -1,0 +1,7 @@
+haystack:
+  graphite:
+     prefix: "haystack"
+     address: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+     port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+     pollIntervalSeconds: 60
+     queueSize: 10

--- a/haystack-commons/src/main/resources/logback.xml
+++ b/haystack-commons/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoder default type is ch.qos.logback.classic.encoder.PatternLayoutEncoder-->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %level [%thread] %X{requestid} %logger{10} %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="com.netflix.servo.publish.graphite.GraphiteMetricObserver" additivity="false" level="INFO">
+        <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+    </logger>
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConventionTest.java
+++ b/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConventionTest.java
@@ -1,0 +1,114 @@
+package com.expedia.www.haystack.metrics;
+
+import com.netflix.servo.Metric;
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.tag.BasicTagList;
+import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.Tags;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.HOST_NAME_UNKNOWN_HOST_EXCEPTION;
+import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.LOCAL_HOST_NAME;
+import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.METRIC_FORMAT;
+import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.MISSING_TAG;
+import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.MISSING_VALUE;
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_CLASS;
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HaystackGraphiteNamingConventionTest {
+    private final static Random RANDOM = new Random();
+    private final static String METRIC_NAME = RANDOM.nextLong() + "METRIC_NAME";
+    private final static String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
+    private final static String CLASS = RANDOM.nextLong() + "CLASS";
+    private final static String TYPE = RANDOM.nextLong() + "TYPE";
+
+    @Mock
+    private HaystackGraphiteNamingConvention.Factory mockFactory;
+    private HaystackGraphiteNamingConvention.Factory realFactory;
+
+    @Mock
+    private InetAddress mockLocalHost;
+
+    private HaystackGraphiteNamingConvention haystackGraphiteNamingConvention;
+
+    @Before
+    public void setUp() {
+        realFactory = HaystackGraphiteNamingConvention.factory;
+        HaystackGraphiteNamingConvention.factory = mockFactory;
+        haystackGraphiteNamingConvention = new HaystackGraphiteNamingConvention();
+    }
+
+    @After
+    public void tearDown() {
+        HaystackGraphiteNamingConvention.factory = realFactory;
+        verifyNoMoreInteractions(mockFactory, mockLocalHost);
+    }
+
+    @Test
+    public void testThatStaticHostNameIsLocalHost() throws UnknownHostException {
+        final String expected = InetAddress.getLocalHost().getHostName().replace(" ", "_").replace(".", "_");
+        assertEquals(expected, LOCAL_HOST_NAME);
+    }
+
+    @Test
+    public void testGetLocalHostException() throws UnknownHostException {
+        when(mockFactory.getLocalHost()).thenThrow(new UnknownHostException());
+
+        final String localHost = HaystackGraphiteNamingConvention.getLocalHost();
+        assertEquals(HOST_NAME_UNKNOWN_HOST_EXCEPTION, localHost);
+
+        verify(mockFactory).getLocalHost();
+    }
+
+    @Test
+    public void testGetLocalHostNullHostName() throws UnknownHostException {
+        when(mockFactory.getLocalHost()).thenReturn(mockLocalHost);
+
+        final String localHost = HaystackGraphiteNamingConvention.getLocalHost();
+        assertEquals(String.format(MISSING_VALUE, ""), localHost);
+
+        verify(mockFactory).getLocalHost();
+        //noinspection ResultOfMethodCallIgnored
+        verify(mockLocalHost).getHostName();
+    }
+
+    @Test
+    public void testGetNameAllNull() {
+        final Metric metric = new Metric(METRIC_NAME, BasicTagList.EMPTY, 0, 0);
+
+        final String name = haystackGraphiteNamingConvention.getName(metric);
+
+        final String expected = String.format(METRIC_FORMAT, LOCAL_HOST_NAME, String.format(MISSING_TAG, TAG_KEY_SUBSYSTEM),
+                String.format(MISSING_TAG, TAG_KEY_CLASS), METRIC_NAME, String.format(MISSING_TAG, DataSourceType.KEY));
+        assertEquals(expected, name);
+    }
+
+    @Test
+    public void testGetNameNoneNull() {
+        final List<Tag> tagList = new ArrayList<>(3);
+        tagList.add(Tags.newTag(TAG_KEY_SUBSYSTEM, SUBSYSTEM));
+        tagList.add(Tags.newTag(TAG_KEY_CLASS, CLASS));
+        tagList.add(Tags.newTag(DataSourceType.KEY, TYPE));
+        final Metric metric = new Metric(METRIC_NAME, new BasicTagList(tagList), 0, 0);
+
+        final String name = haystackGraphiteNamingConvention.getName(metric);
+
+        assertEquals(String.format(METRIC_FORMAT, LOCAL_HOST_NAME, SUBSYSTEM, CLASS, METRIC_NAME, TYPE), name);
+    }
+}

--- a/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConventionTest.java
+++ b/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConventionTest.java
@@ -94,8 +94,9 @@ public class HaystackGraphiteNamingConventionTest {
 
         final String name = haystackGraphiteNamingConvention.getName(metric);
 
-        final String expected = String.format(METRIC_FORMAT, LOCAL_HOST_NAME, String.format(MISSING_TAG, TAG_KEY_SUBSYSTEM),
-                String.format(MISSING_TAG, TAG_KEY_CLASS), METRIC_NAME, String.format(MISSING_TAG, DataSourceType.KEY));
+        final String expected = String.format(METRIC_FORMAT, String.format(MISSING_TAG, TAG_KEY_SUBSYSTEM),
+                LOCAL_HOST_NAME, String.format(MISSING_TAG, TAG_KEY_CLASS), METRIC_NAME,
+                String.format(MISSING_TAG, DataSourceType.KEY));
         assertEquals(expected, name);
     }
 
@@ -109,6 +110,6 @@ public class HaystackGraphiteNamingConventionTest {
 
         final String name = haystackGraphiteNamingConvention.getName(metric);
 
-        assertEquals(String.format(METRIC_FORMAT, LOCAL_HOST_NAME, SUBSYSTEM, CLASS, METRIC_NAME, TYPE), name);
+        assertEquals(String.format(METRIC_FORMAT, SUBSYSTEM, LOCAL_HOST_NAME, CLASS, METRIC_NAME, TYPE), name);
     }
 }

--- a/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
+++ b/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
@@ -33,20 +33,22 @@ public class MetricObjectsTest {
 
     @Mock
     private MetricObjects.Factory mockFactory;
-    private MetricObjects.Factory realFactory;
 
     @Mock
     private MonitorRegistry mockMonitorRegistry;
 
+    // Objects under test
+    private MetricObjects metricObjects;
+    private MetricObjects.Factory factory;
+
     @Before
     public void setUp() {
-        realFactory = MetricObjects.factory;
-        MetricObjects.factory = mockFactory;
+        metricObjects = new MetricObjects(mockFactory);
+        factory = new MetricObjects.Factory();
     }
 
     @After
     public void tearDown() {
-        MetricObjects.factory = realFactory;
         verifyNoMoreInteractions(mockFactory, mockMonitorRegistry);
     }
 
@@ -54,7 +56,7 @@ public class MetricObjectsTest {
     public void testCreateAndRegisterCounter() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Counter counter = MetricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS, METRIC_NAME);
+        final Counter counter = metricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS, METRIC_NAME);
 
         assertsAndVerifiesForCreateAndRegister(counter);
     }
@@ -63,7 +65,7 @@ public class MetricObjectsTest {
     public void testCreateAndRegisterTimer() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Timer timer = MetricObjects.createAndRegisterTimer(SUBSYSTEM, CLASS, METRIC_NAME, TimeUnit.MILLISECONDS);
+        final Timer timer = metricObjects.createAndRegisterTimer(SUBSYSTEM, CLASS, METRIC_NAME, TimeUnit.MILLISECONDS);
 
         assertsAndVerifiesForCreateAndRegister(timer);
     }
@@ -80,7 +82,7 @@ public class MetricObjectsTest {
 
     @Test
     public void testFactoryGetDefaultMonitorRegisterInstance() {
-        assertSame(DefaultMonitorRegistry.getInstance(), realFactory.getMonitorRegistry());
+        assertSame(DefaultMonitorRegistry.getInstance(), factory.getMonitorRegistry());
     }
 
     @Test

--- a/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
+++ b/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
@@ -1,0 +1,90 @@
+package com.expedia.www.haystack.metrics;
+
+import com.netflix.servo.DefaultMonitorRegistry;
+import com.netflix.servo.MonitorRegistry;
+import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.Monitor;
+import com.netflix.servo.monitor.Timer;
+import com.netflix.servo.tag.TagList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_CLASS;
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetricObjectsTest {
+    private final static Random RANDOM = new Random();
+    private final static String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
+    private final static String CLASS = RANDOM.nextLong() + "CLASS";
+    private final static String METRIC_NAME = RANDOM.nextLong() + "METRIC_NAME";
+
+    @Mock
+    private MetricObjects.Factory mockFactory;
+    private MetricObjects.Factory realFactory;
+
+    @Mock
+    private MonitorRegistry mockMonitorRegistry;
+
+    @Before
+    public void setUp() {
+        realFactory = MetricObjects.factory;
+        MetricObjects.factory = mockFactory;
+    }
+
+    @After
+    public void tearDown() {
+        MetricObjects.factory = realFactory;
+        verifyNoMoreInteractions(mockFactory, mockMonitorRegistry);
+    }
+
+    @Test
+    public void testCreateAndRegisterCounter() {
+        when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
+
+        final Counter counter = MetricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS, METRIC_NAME);
+
+        assertsAndVerifiesForCreateAndRegister(counter);
+    }
+
+    @Test
+    public void testCreateAndRegisterTimer() {
+        when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
+
+        final Timer timer = MetricObjects.createAndRegisterTimer(SUBSYSTEM, CLASS, METRIC_NAME, TimeUnit.MILLISECONDS);
+
+        assertsAndVerifiesForCreateAndRegister(timer);
+    }
+
+    private void assertsAndVerifiesForCreateAndRegister(Monitor<?> monitor) {
+        final TagList tagList = monitor.getConfig().getTags();
+        assertEquals(2, tagList.size());
+        assertEquals(SUBSYSTEM, tagList.getValue(TAG_KEY_SUBSYSTEM));
+        assertEquals(CLASS, tagList.getValue(TAG_KEY_CLASS));
+        assertEquals(METRIC_NAME, monitor.getConfig().getName());
+        verify(mockMonitorRegistry).register(monitor);
+        verify(mockFactory).getMonitorRegistry();
+    }
+
+    @Test
+    public void testFactoryGetDefaultMonitorRegisterInstance() {
+        assertSame(DefaultMonitorRegistry.getInstance(), realFactory.getMonitorRegistry());
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        new MetricObjects();
+    }
+}

--- a/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
+++ b/haystack-commons/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
@@ -1,0 +1,245 @@
+package com.expedia.www.haystack.metrics;
+
+import com.netflix.servo.Metric;
+import com.netflix.servo.publish.AsyncMetricObserver;
+import com.netflix.servo.publish.BasicMetricFilter;
+import com.netflix.servo.publish.CounterToRateMetricTransform;
+import com.netflix.servo.publish.MetricFilter;
+import com.netflix.servo.publish.MetricObserver;
+import com.netflix.servo.publish.MetricPoller;
+import com.netflix.servo.publish.MonitorRegistryMetricPoller;
+import com.netflix.servo.publish.PollRunnable;
+import com.netflix.servo.publish.PollScheduler;
+import com.netflix.servo.publish.graphite.GraphiteMetricObserver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.expedia.www.haystack.metrics.MetricPublishing.ASYNC_METRIC_OBSERVER_NAME;
+import static com.expedia.www.haystack.metrics.MetricPublishing.POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER;
+import static com.expedia.www.haystack.metrics.MetricPublishing.POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetricPublishingTest {
+    private static final Random RANDOM = new Random();
+    private static final int POLL_INTERVAL_SECONDS = RANDOM.nextInt(Short.MAX_VALUE);
+    private static final int QUEUE_SIZE = RANDOM.nextInt(Byte.MAX_VALUE) + 1;
+    private static final long EXPIRE_TIME = POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER * POLL_INTERVAL_SECONDS;
+    private static final long HEARTBEAT = POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER * POLL_INTERVAL_SECONDS;
+    private static final String ADDRESS = String.format("%d.%d.%d.%d", RANDOM.nextInt(Byte.MAX_VALUE),
+            RANDOM.nextInt(Byte.MAX_VALUE), RANDOM.nextInt(Byte.MAX_VALUE), RANDOM.nextInt(Byte.MAX_VALUE));
+    private static final String PREFIX = RANDOM.nextLong() + "PREFIX";
+    private static final int PORT = RANDOM.nextInt(Short.MAX_VALUE);
+    private static final String ADDRESS_AND_PORT = ADDRESS + ':' + PORT;
+
+    @Mock
+    private MetricPublishing.Factory mockFactory;
+    private MetricPublishing.Factory realFactory;
+
+    @Mock
+    private MetricObserver mockMetricObserver;
+
+    @Mock
+    private GraphiteConfig mockGraphiteConfig;
+    private GraphiteConfig realGraphiteConfig;
+
+    @Mock
+    private MetricObserver mockAsyncMetricObserver;
+
+    @Mock
+    private MetricObserver mockCounterToRateMetricTransform;
+
+    @Mock
+    private MetricObserver mockGraphiteMetricObserver;
+
+    @Mock
+    private PollRunnable mockTask;
+
+    @Mock
+    private MetricPoller mockMetricPoller;
+
+    @Before
+    public void setUp() {
+        realFactory = MetricPublishing.factory;
+        realGraphiteConfig = MetricPublishing.graphiteConfig;
+        MetricPublishing.factory = mockFactory;
+        MetricPublishing.graphiteConfig = mockGraphiteConfig;
+    }
+
+    @After
+    public void tearDown() {
+        MetricPublishing.factory = realFactory;
+        MetricPublishing.graphiteConfig = realGraphiteConfig;
+        if(PollScheduler.getInstance().isStarted()) {
+            PollScheduler.getInstance().stop();
+        }
+        verifyNoMoreInteractions(mockFactory, mockMetricObserver, mockGraphiteConfig, mockAsyncMetricObserver,
+                mockCounterToRateMetricTransform, mockGraphiteMetricObserver, mockTask, mockMetricPoller);
+    }
+
+    @Test
+    public void testStart() throws UnknownHostException {
+        final List<MetricObserver> observers = whensForStart();
+
+        MetricPublishing.start();
+
+        verifiesForStart(observers);
+    }
+
+    private List<MetricObserver> whensForStart() {
+        whensForCreateGraphiteObserver();
+        when(mockFactory.createMonitorRegistryMetricPoller()).thenReturn(mockMetricPoller);
+        when(mockFactory.createTask(any(MetricPoller.class), anyListOf(MetricObserver.class))).thenReturn(mockTask);
+        return Collections.singletonList(mockCounterToRateMetricTransform);
+    }
+
+    private void verifiesForStart(List<MetricObserver> observers) throws UnknownHostException {
+        verifiesForCreateGraphiteObserver(3);
+        verify(mockFactory).createMonitorRegistryMetricPoller();
+        verify(mockFactory).createTask(mockMetricPoller, observers);
+        verify(mockTask).run();
+    }
+
+    @Test
+    public void testCreateGraphiteObserver() throws UnknownHostException {
+        whensForCreateGraphiteObserver();
+
+        final MetricObserver metricObserver = MetricPublishing.createGraphiteObserver();
+        assertSame(mockCounterToRateMetricTransform, metricObserver);
+
+        verifiesForCreateGraphiteObserver(2);
+    }
+
+    private void whensForCreateGraphiteObserver() {
+        whensForAsync();
+        whensForRateTransform();
+        when(mockGraphiteConfig.address()).thenReturn(ADDRESS);
+        when(mockGraphiteConfig.port()).thenReturn(PORT);
+        when(mockFactory.createGraphiteMetricObserver(anyString(), anyString())).thenReturn(mockGraphiteMetricObserver);
+    }
+
+    private void verifiesForCreateGraphiteObserver(int pollIntervalSecondsTimes) throws UnknownHostException {
+        verifiesForAsync(pollIntervalSecondsTimes, mockGraphiteMetricObserver);
+        verifiesForRateTransform(pollIntervalSecondsTimes, mockAsyncMetricObserver);
+        verify(mockGraphiteConfig).address();
+        verify(mockGraphiteConfig).port();
+        verify(mockFactory).createGraphiteMetricObserver(ASYNC_METRIC_OBSERVER_NAME, ADDRESS_AND_PORT);
+    }
+
+    @Test
+    public void testRateTransform() {
+        whensForRateTransform();
+
+        final MetricObserver metricObserver = MetricPublishing.rateTransform(mockMetricObserver);
+        assertSame(mockCounterToRateMetricTransform, metricObserver);
+
+        verifiesForRateTransform(1, mockMetricObserver);
+    }
+
+    private void whensForRateTransform() {
+        when(mockFactory.createCounterToRateMetricTransform(any(MetricObserver.class), anyLong(), any(TimeUnit.class)))
+                .thenReturn(mockCounterToRateMetricTransform);
+        when(mockGraphiteConfig.pollIntervalSeconds()).thenReturn(POLL_INTERVAL_SECONDS);
+    }
+
+    private void verifiesForRateTransform(int pollIntervalSecondsTimes, MetricObserver metricObserver) {
+        verify(mockFactory).createCounterToRateMetricTransform(metricObserver, HEARTBEAT, TimeUnit.SECONDS);
+        verify(mockGraphiteConfig, times(pollIntervalSecondsTimes)).pollIntervalSeconds();
+    }
+
+    @Test
+    public void testAsync() {
+        whensForAsync();
+
+        final MetricObserver metricObserver = MetricPublishing.async(mockMetricObserver);
+        assertSame(mockAsyncMetricObserver, metricObserver);
+
+        verifiesForAsync(1, mockMetricObserver);
+    }
+
+    private void whensForAsync() {
+        when(mockGraphiteConfig.pollIntervalSeconds()).thenReturn(POLL_INTERVAL_SECONDS);
+        when(mockGraphiteConfig.queueSize()).thenReturn(QUEUE_SIZE);
+        when(mockFactory.createAsyncMetricObserver(any(MetricObserver.class), anyInt(), anyLong()))
+                .thenReturn(mockAsyncMetricObserver);
+    }
+
+    private void verifiesForAsync(int pollIntervalSecondsTimes, MetricObserver metricObserver) {
+        verify(mockGraphiteConfig, times(pollIntervalSecondsTimes)).pollIntervalSeconds();
+        verify(mockGraphiteConfig).queueSize();
+        verify(mockFactory).createAsyncMetricObserver(
+                metricObserver, QUEUE_SIZE, EXPIRE_TIME);
+    }
+
+    @Test
+    public void testFactoryCreateAsyncMetricObserver() {
+        final MetricObserver metricObserver = realFactory.createAsyncMetricObserver(
+                mockMetricObserver, QUEUE_SIZE, EXPIRE_TIME);
+        assertEquals(ASYNC_METRIC_OBSERVER_NAME, metricObserver.getName());
+        assertEquals(AsyncMetricObserver.class, metricObserver.getClass());
+    }
+
+    @Test
+    public void testFactoryCreateCounterToRateMetricTransform() {
+        when(mockMetricObserver.getName()).thenReturn(ASYNC_METRIC_OBSERVER_NAME);
+
+        final MetricObserver metricObserver = realFactory.createCounterToRateMetricTransform(
+                mockMetricObserver, HEARTBEAT, TimeUnit.SECONDS);
+
+        assertEquals(ASYNC_METRIC_OBSERVER_NAME, metricObserver.getName());
+        assertEquals(CounterToRateMetricTransform.class, metricObserver.getClass());
+        verify(mockMetricObserver).getName();
+    }
+
+    @Test
+    public void testFactoryCreateGraphiteMetricObserver() {
+        final MetricObserver metricObserver = realFactory.createGraphiteMetricObserver(PREFIX, ADDRESS_AND_PORT);
+        assertEquals("GraphiteMetricObserver" + PREFIX, metricObserver.getName());
+        assertEquals(GraphiteMetricObserver.class, metricObserver.getClass());
+    }
+
+    @Test
+    public void testFactoryCreateTask() {
+        when(mockMetricPoller.poll(any(MetricFilter.class), anyBoolean())).thenReturn(Collections.emptyList());
+
+        final PollRunnable task = realFactory.createTask(mockMetricPoller, Collections.emptyList());
+        task.run();
+
+        verify(mockMetricPoller).poll(BasicMetricFilter.MATCH_ALL, true);
+    }
+
+    @Test
+    public void testFactoryCreateMonitorRegistryMetricPoller() {
+        when(mockMetricPoller.poll(any(MetricFilter.class), anyBoolean())).thenReturn(Collections.emptyList());
+
+        final MetricPoller metricPoller = realFactory.createMonitorRegistryMetricPoller();
+
+        assertEquals(MonitorRegistryMetricPoller.class, metricPoller.getClass());
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        new MetricPublishing();
+    }
+}


### PR DESCRIPTION
Initial code facilitates creating Servo objects (generic Counter or
Timer are currently supported) and pushes metrics from those Servo
objects to InfluxDb, via graphite messages. The graphite messages are
then split into InfluxDb style tags and measurements and written to the
database.