### PR TITLE
More tweaks for haystack-commons:

### DIFF
--- a/commons/README.md
+++ b/commons/README.md
@@ -122,7 +122,7 @@ InfluxDb via the OpenTSDB protocol does not currently exist; instead, the bridge
 and an InfluxDb template (read about them in this 
 [README](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) file) parses the Graphite plain
 text message into tags. (You can read about metrics tags 
-[here](http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html).))
+[here](http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html).)
 
 This graphite bridge therefore requires a convention to map each metric piece to a tag; this convention is found/used in 
 three places that must agree on the convention:
@@ -138,7 +138,7 @@ As a result, the graphite message has the following meaning:
 <system>.<server>.<subsystem>.<class>.<VARIABLE_NAME>_<METRIC_NAME>
 ```
 where:
-* `<system>` is always "haystack"
+* `<system>` is typically "haystack" (this value is controlled by the `haystack.graphite.prefix` configuration)
 * `<server>` is the host name
 * `<subsystem>` is the value discussed in the "Subsystem" section above
 * `<class>` is the  value discussed in the "Class" section above

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -3,14 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-commons</artifactId>
     <version>0.1</version>
     <packaging>jar</packaging>
 
-    <name>haystack-commons</name>
-    <description>Code needed by all or most Haystack packages</description>
-    <url>http://maven.apache.org</url>
+    <scm>
+        <connection>scm:git:git://github.com/ExpediaDotCom/haystack.git</connection>
+        <developerConnection>scm:git:ssh://github.com/ExpediaDotCom/haystack.git</developerConnection>
+        <url>http://github.com/ExpediaDotCom/haystack/tree/master/common</url>
+    </scm>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Code needed by all or most other Haystack packages</description>
+    <url>https://github.com/ExpediaDotCom/haystack/tree/master/commons</url>
 
     <licenses>
         <!--
@@ -38,6 +45,15 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <name>Jeff Baker</name>
+            <email>jeffbaker@expedia.com</email>
+            <organization>Haystack</organization>
+            <organizationUrl>https://expediadotcom.github.io/haystack/infrastructure/section.html</organizationUrl>
+        </developer>
+    </developers>
 
     <properties>
         <cfg4j-core-version>4.4.1</cfg4j-core-version>
@@ -100,7 +116,7 @@
                 <version>${maven-jar-plugin-version}</version>
             </plugin>
             <plugin>
-                <!-- Include source files in the jar -->
+                <!-- Build a source JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
@@ -113,7 +129,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- Include javadoc in the jar -->
+                <!-- Build a JavaDoc JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>

--- a/commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
+++ b/commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
@@ -36,7 +36,7 @@ public class MetricObjects {
      *
      * @param factory The Factory to use to obtain a MonitorRegistry
      */
-    public MetricObjects(Factory factory) {
+    MetricObjects(Factory factory) {
         this.factory = factory;
     }
 

--- a/commons/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
+++ b/commons/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
@@ -53,8 +53,10 @@ public class MetricPublishing {
     /**
      * Creates a new instance of MetricPublishing with a user-specified Factory; intended to be used by unit-test code
      * so that the Factory can be mocked.
+     *
+     * @param factory The factory to use.
      */
-    public MetricPublishing(Factory factory) {
+    MetricPublishing(Factory factory) {
         this.factory = factory;
     }
 
@@ -90,11 +92,11 @@ public class MetricPublishing {
     /**
      * Factory to wrap static or final methods; this Factory facilitates unit testing
      */
-    public static class Factory {
+    static class Factory {
         /**
          * The default (and only) constructor.
          */
-        public Factory() {
+        Factory() {
             // default constructor
         }
 
@@ -107,7 +109,7 @@ public class MetricPublishing {
          *                   observer.
          * @return the MetricObserver
          */
-        public MetricObserver createAsyncMetricObserver(MetricObserver observer, int queueSize, long expireTime) {
+        MetricObserver createAsyncMetricObserver(MetricObserver observer, int queueSize, long expireTime) {
             return new AsyncMetricObserver(ASYNC_METRIC_OBSERVER_NAME, observer, queueSize, expireTime);
         }
 
@@ -120,7 +122,7 @@ public class MetricPublishing {
          * @param timeUnit  Time unit for the heartbeat parameter
          * @return the MetricObserver
          */
-        public MetricObserver createCounterToRateMetricTransform(
+        MetricObserver createCounterToRateMetricTransform(
                 MetricObserver observer, long heartbeat, TimeUnit timeUnit) {
             return new CounterToRateMetricTransform(observer, heartbeat, timeUnit);
         }
@@ -132,7 +134,7 @@ public class MetricPublishing {
          * @param address address of the graphite data port in "host:port" format.
          * @return The Observer that will shunt the metrics to Graphite
          */
-        public MetricObserver createGraphiteMetricObserver(String prefix, String address) {
+        MetricObserver createGraphiteMetricObserver(String prefix, String address) {
             String hostName;
             try {
                 hostName = InetAddress.getLocalHost().getHostName();
@@ -151,7 +153,7 @@ public class MetricPublishing {
          * @param observers the Observers that will receive the polled metrics
          * @return the Runnable
          */
-        public PollRunnable createTask(MetricPoller poller, Collection<MetricObserver> observers) {
+        PollRunnable createTask(MetricPoller poller, Collection<MetricObserver> observers) {
             return new PollRunnable(poller, BasicMetricFilter.MATCH_ALL, true, observers);
         }
 
@@ -160,7 +162,7 @@ public class MetricPublishing {
          *
          * @return the MetricPoller
          */
-        public MetricPoller createMonitorRegistryMetricPoller() {
+        MetricPoller createMonitorRegistryMetricPoller() {
             return new MonitorRegistryMetricPoller();
         }
     }


### PR DESCRIPTION
Make the Factory classes and methods package private; their being public
is not necessary for other packages to write unit tests, and clutters
the JavaDoc.
Add more elements to pom.xml per the instructions at
http://central.sonatype.org/pages/requirements.html preparing for
publishing artifacts.