### PR TITLE
Rework how BasicTimer is used:

### DIFF
--- a/commons/README.md
+++ b/commons/README.md
@@ -66,14 +66,17 @@ Simply increment the Counter to count:
 REQUEST.increment();
 ```
 It will be reset when its value is reported to InfluxDb.
-#### Timer
+#### BasicTimer
 ##### Creation
-The code below is a Java snippet that shows the right way to create a Timer:
+The code below is a Java snippet that shows the right way to create a BasicTimer:
 ```
-static final Timer JSON_SERIALIZATION = (new MetricObjects()).createAndRegisterTimer(SUBSYSTEM, KLASS_NAME, "JSON_SERIALIZATION", TimeUnit.MICROSECONDS);
+static final Timer JSON_SERIALIZATION = (new MetricObjects()).createAndRegisterTimer(
+    SUBSYSTEM, KLASS_NAME, "JSON_SERIALIZATION", TimeUnit.MICROSECONDS);
 ```
-The Servo Timer generates two metrics (GAUGE and NORMALIZED), and using upper case is again suggested (see the Counter 
-section above) to create complete metric names of `JSON_SERIALIZATION_GAUGE` and `JSON_SERIALIZATION_NORMALIZED`.
+The Servo Timer generates four metrics (GAUGE max, NORMALIZED count, NORMALIZED totalOfSquares, and NORMALIZED
+totalTime), and while using upper case is again suggested (see the Counter section above), the complete metric names 
+(`JSON_SERIALIZATION_GAUGE_min`, `JSON_SERIALIZATION_NORMALIZED_count`, `JSON_SERIALIZATION_NORMALIZED_totalOfSquares`, 
+and `JSON_SERIALIZATION_NORMALIZED_totalTime`) are mixed case.
 Choose the appropriate time unit as the last argument:
 * For on-host code, `TimeUnit.MICROSECONDS` is probably appropriate.
 * For network calls, `TimeUnit.MILLISECONDS` may be sufficient.
@@ -90,6 +93,10 @@ try {
 } finally {
     stopwatch.stop();
 }
+```
+You can also do your own timing without using a Stopwatch:
+```
+JSON_SERIALIZATION.record(timeItTookInMs, TimeUnit.MILLISECONDS);
 ```
 Again, the Timer will be reset when its values are reported to InfluxDb.
 #### The Main Method
@@ -142,5 +149,5 @@ where:
 * `<server>` is the host name
 * `<subsystem>` is the value discussed in the "Subsystem" section above
 * `<class>` is the  value discussed in the "Class" section above
-* `<VARIABLE_NAME>_<METRIC_NAME>` is the complete metric name; see `REQUEST_RATE`, `JSON_SERIALIZATION_GAUGE`, and 
-`JSON_SERIALIZATION_NORMALIZED` in the "Counter" and "Timer" sections above.
+* `<VARIABLE_NAME>_<METRIC_NAME>_<timerStatName>` is the complete metric name; see the "Counter" and "BasicTimer" 
+sections above.

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -59,7 +59,9 @@
         <cfg4j-core-version>4.4.1</cfg4j-core-version>
         <junit-version>4.12</junit-version>
         <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
+        <maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
         <maven-jar-plugin-version>3.0.2</maven-jar-plugin-version>
+        <maven-source-plugin-version>3.0.1</maven-source-plugin-version>
         <mockito-version>1.9.5</mockito-version>
         <servo-version>0.12.17</servo-version>
         <slf4j-version>1.7.25</slf4j-version>
@@ -119,6 +121,7 @@
                 <!-- Build a source JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -132,6 +135,7 @@
                 <!-- Build a JavaDoc JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/commons/src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java
+++ b/commons/src/main/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConvention.java
@@ -16,6 +16,7 @@ import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
 public class HaystackGraphiteNamingConvention implements GraphiteNamingConvention {
     static final String MISSING_TAG = "MISSING_TAG_%s";
     static final String METRIC_FORMAT = "%s.%s.%s.%s_%s";
+    static final String STATISTIC_TAG_NAME = "statistic";
 
     private final String hostName;
 
@@ -48,7 +49,12 @@ public class HaystackGraphiteNamingConvention implements GraphiteNamingConventio
         final String klass = cleanup(tags, TAG_KEY_CLASS);
         final String configName = config.getName(); // Servo disallows null for name, no need to cleanup
         final String type = cleanup(tags, DataSourceType.KEY);
-        return String.format(METRIC_FORMAT, subsystem, hostName, klass, configName, type);
+
+        // Timer comes with a statistic tag; Counter does not
+        final Tag statisticTag = tags.getTag(STATISTIC_TAG_NAME);
+        final String statisticName = statisticTag == null ? null : statisticTag.getValue();
+        final String metricName = statisticName == null ? type : type + '_' + statisticName;
+        return String.format(METRIC_FORMAT, subsystem, hostName, klass, configName, metricName);
     }
 
     private static String cleanup(TagList tags, String name) {

--- a/commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
+++ b/commons/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
@@ -2,9 +2,10 @@ package com.expedia.www.haystack.metrics;
 
 import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.MonitorRegistry;
+import com.netflix.servo.monitor.BasicTimer;
 import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.MonitorConfig;
 import com.netflix.servo.monitor.Monitors;
-import com.netflix.servo.monitor.Timer;
 import com.netflix.servo.tag.BasicTagList;
 import com.netflix.servo.tag.SmallTagMap;
 import com.netflix.servo.tag.TagList;
@@ -57,21 +58,22 @@ public class MetricObjects {
     }
 
     /**
-     * Creates a new Timer; you should only call this method once for each Timer in your code.
+     * Creates a new BasicTimer; you should only call this method once for each BasicTimer in your code.
      *
      * @param subsystem the subsystem, typically something like "pipes" or "trends".
      * @param klass     the metric class, frequently (but not necessarily) the class containing the Timer.
      * @param timerName the name of the Timer, usually the name of the variable holding the Timer instance
      *                  using upper case for timerName is recommended.
-     * @param timeUnit  desired precision, typically TimeUnit.MILLISECONDS; use TimeUnit.MICROSECONDS or
-     *                  TimeUnit.NANOSECONDS (rare) for more precision.
+     * @param timeUnit  desired precision, typically TimeUnit.MILLISECONDS; use TimeUnit.NANOSECONDS (rare) or
+     *                  TimeUnit.MICROSECONDS for more precision.
      * @return a new Timer that this method registers in the DefaultMonitorRegistry before returning it.
      */
-    public Timer createAndRegisterTimer(String subsystem, String klass, String timerName, TimeUnit timeUnit) {
+    public BasicTimer createAndRegisterBasicTimer(String subsystem, String klass, String timerName, TimeUnit timeUnit) {
         final TaggingContext taggingContext = () -> getTags(subsystem, klass);
-        final Timer timer = Monitors.newTimer(timerName, timeUnit, taggingContext);
-        factory.getMonitorRegistry().register(timer);
-        return timer;
+        final MonitorConfig.Builder builder = MonitorConfig.builder(timerName).withTags(taggingContext.getTags());
+        final BasicTimer basicTimer = new BasicTimer(builder.build(), timeUnit);
+        factory.getMonitorRegistry().register(basicTimer);
+        return basicTimer;
     }
 
     private static TagList getTags(String subsystem, String klass) {

--- a/commons/src/test/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConventionTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/metrics/HaystackGraphiteNamingConventionTest.java
@@ -19,6 +19,7 @@ import java.util.Random;
 
 import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.METRIC_FORMAT;
 import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.MISSING_TAG;
+import static com.expedia.www.haystack.metrics.HaystackGraphiteNamingConvention.STATISTIC_TAG_NAME;
 import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_CLASS;
 import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
 import static org.junit.Assert.assertEquals;
@@ -31,6 +32,7 @@ public class HaystackGraphiteNamingConventionTest {
     private final static String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
     private final static String CLASS = RANDOM.nextLong() + "CLASS";
     private final static String TYPE = RANDOM.nextLong() + "TYPE";
+    private final static String STATISTIC = RANDOM.nextLong() + "STATISTIC";
     private final static String LOCAL_HOST_NAME = "127.0.0.1";
     private final static String LOCAL_HOST_NAME_CLEANED = LOCAL_HOST_NAME.replace(".", "_");
 
@@ -62,7 +64,7 @@ public class HaystackGraphiteNamingConventionTest {
     }
 
     @Test
-    public void testGetNameNoneNull() {
+    public void testGetNameNoneNullWithoutStatistic() {
         final List<Tag> tagList = new ArrayList<>(3);
         tagList.add(Tags.newTag(TAG_KEY_SUBSYSTEM, SUBSYSTEM));
         tagList.add(Tags.newTag(TAG_KEY_CLASS, CLASS));
@@ -72,5 +74,21 @@ public class HaystackGraphiteNamingConventionTest {
         final String name = haystackGraphiteNamingConvention.getName(metric);
 
         assertEquals(String.format(METRIC_FORMAT, SUBSYSTEM, LOCAL_HOST_NAME_CLEANED, CLASS, METRIC_NAME, TYPE), name);
+    }
+
+    @Test
+    public void testGetNameNoneNullWithStatistic() {
+        final List<Tag> tagList = new ArrayList<>(4);
+        tagList.add(Tags.newTag(TAG_KEY_SUBSYSTEM, SUBSYSTEM));
+        tagList.add(Tags.newTag(TAG_KEY_CLASS, CLASS));
+        tagList.add(Tags.newTag(DataSourceType.KEY, TYPE));
+        tagList.add(Tags.newTag(STATISTIC_TAG_NAME, STATISTIC));
+        final Metric metric = new Metric(METRIC_NAME, new BasicTagList(tagList), 0, 0);
+
+        final String name = haystackGraphiteNamingConvention.getName(metric);
+
+        final String expected = String.format(METRIC_FORMAT,
+                SUBSYSTEM, LOCAL_HOST_NAME_CLEANED, CLASS, METRIC_NAME, TYPE + '_' + STATISTIC);
+        assertEquals(expected, name);
     }
 }

--- a/commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
@@ -14,10 +14,10 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_CLASS;
 import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.verify;
@@ -62,10 +62,10 @@ public class MetricObjectsTest {
     }
 
     @Test
-    public void testCreateAndRegisterTimer() {
+    public void testCreateAndRegisterBasicTimer() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Timer timer = metricObjects.createAndRegisterTimer(SUBSYSTEM, CLASS, METRIC_NAME, TimeUnit.MILLISECONDS);
+        final Timer timer = metricObjects.createAndRegisterBasicTimer(SUBSYSTEM, CLASS, METRIC_NAME, MILLISECONDS);
 
         assertsAndVerifiesForCreateAndRegister(timer);
     }


### PR DESCRIPTION
Use BasicTimer instead of CompositeTimer from Metrics.createTimer().
Use the "statistic" tag if present to generate the metric name.
Change createAndRegisterTimer to createAndRegisterBasicTimer, to prepare
for BucketTimer.