### PR TITLE
Disallow duplicate Monitor objects (Timers and Counters).

### DIFF
--- a/commons/README.md
+++ b/commons/README.md
@@ -50,7 +50,14 @@ private static final String CLASS_NAME = "JsonSerialization";
 ```
 ##### Singleton
 Your Servo objects should be singletons, either as static (Java) or object (Scala) variables. The MetricObjects
-variable can be managed by a Dependency Injection (DI) framework or not, as you see fit.
+variable can be managed by a Dependency Injection (DI) framework or not, as you see fit. Servo objects are specified
+with Identifiers:
+1. Subsystem
+2. Class Name
+3. Metric Name
+If a Counter or Timer is created twice (that is, its Identifiers match that of an already registered Counter or Timer),
+then a warning will be logged and the existing object returned by the createAndRegister call. A Timer and a Counter 
+with matching Identifiers is allowed but best avoided.
 #### Counter
 ##### Creation
 The code below is a Java snippet that shows the right way to create a Counter:
@@ -102,8 +109,9 @@ Again, the Timer will be reset when its values are reported to InfluxDb.
 #### The Main Method
 To initialize the metrics system, the first line of your main() method should be something like:
 ```
-(new MetricPublishing()).start();
+(new MetricPublishing()).start(graphiteConfig);
 ```
+where graphiteConfig is an implementation of the GraphiteConfig interface declared in this module.
 #### Configuration
 You will typically have a base.yaml in your resources directory whose contents will include:
 ```
@@ -124,9 +132,9 @@ Such a message consists of three space-delimited Strings terminated by a newline
 ```
 The `<metric value>` is a number, and the pieces of `<metric path>` are traditionally separated by a period.
 Note that the period-delimited pieces contain no metadata; that is, the meanings of each piece are not specified in the
-message. This lack of metadata is addressed in [OpenTSDB](http://opentsdb.net) but a bridge to connect Servo metrics to
-InfluxDb via the OpenTSDB protocol does not currently exist; instead, the bridge uses the Graphite plaintext protocol, 
-and an InfluxDb template (read about them in this 
+message. This lack of metadata is addressed in [OpenTSDB](http://opentsdb.net) but code to connect Servo metrics to
+InfluxDb via the OpenTSDB protocol does not currently exist in Servo; instead, the bridge uses the Graphite plaintext 
+protocol, and an InfluxDb template (read about them in this 
 [README](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) file) parses the Graphite plain
 text message into tags. (You can read about metrics tags 
 [here](http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html).)

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -56,7 +56,6 @@
     </developers>
 
     <properties>
-        <cfg4j-core-version>4.4.1</cfg4j-core-version>
         <junit-version>4.12</junit-version>
         <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
         <maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
@@ -68,12 +67,6 @@
     </properties>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/org.cfg4j/cfg4j-core -->
-        <dependency>
-            <groupId>org.cfg4j</groupId>
-            <artifactId>cfg4j-core</artifactId>
-            <version>${cfg4j-core-version}</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/commons/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
@@ -61,7 +61,6 @@ public class MetricPublishingTest {
 
     @Mock
     private GraphiteConfig mockGraphiteConfig;
-    private GraphiteConfig realGraphiteConfig;
 
     @Mock
     private MetricObserver mockAsyncMetricObserver;
@@ -84,15 +83,12 @@ public class MetricPublishingTest {
 
     @Before
     public void setUp() {
-        realGraphiteConfig = MetricPublishing.graphiteConfig;
-        MetricPublishing.graphiteConfig = mockGraphiteConfig;
         metricPublishing = new MetricPublishing(mockFactory);
         factory = new Factory();
     }
 
     @After
     public void tearDown() {
-        MetricPublishing.graphiteConfig = realGraphiteConfig;
         if(PollScheduler.getInstance().isStarted()) {
             PollScheduler.getInstance().stop();
         }
@@ -104,7 +100,7 @@ public class MetricPublishingTest {
     public void testStart() throws UnknownHostException {
         final List<MetricObserver> observers = whensForStart();
 
-        metricPublishing.start();
+        metricPublishing.start(mockGraphiteConfig);
 
         verifiesForStart(observers);
     }
@@ -127,7 +123,7 @@ public class MetricPublishingTest {
     public void testCreateGraphiteObserver() throws UnknownHostException {
         whensForCreateGraphiteObserver();
 
-        final MetricObserver metricObserver = metricPublishing.createGraphiteObserver();
+        final MetricObserver metricObserver = metricPublishing.createGraphiteObserver(mockGraphiteConfig);
         assertSame(mockCounterToRateMetricTransform, metricObserver);
 
         verifiesForCreateGraphiteObserver(2);
@@ -153,7 +149,7 @@ public class MetricPublishingTest {
     public void testRateTransform() {
         whensForRateTransform();
 
-        final MetricObserver metricObserver = metricPublishing.rateTransform(mockMetricObserver);
+        final MetricObserver metricObserver = metricPublishing.rateTransform(mockGraphiteConfig, mockMetricObserver);
         assertSame(mockCounterToRateMetricTransform, metricObserver);
 
         verifiesForRateTransform(1, mockMetricObserver);
@@ -174,7 +170,7 @@ public class MetricPublishingTest {
     public void testAsync() {
         whensForAsync();
 
-        final MetricObserver metricObserver = metricPublishing.async(mockMetricObserver);
+        final MetricObserver metricObserver = metricPublishing.async(mockGraphiteConfig, mockMetricObserver);
         assertSame(mockAsyncMetricObserver, metricObserver);
 
         verifiesForAsync(1, mockMetricObserver);


### PR DESCRIPTION
Remove cfg4j from this library, expecting the clients to pass it in instead.