### PR TITLE
Add "application" field to graphite metric per code review.

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/metrics/ServoToInfluxDbViaGraphiteNamingConvention.java
+++ b/commons/src/main/java/com/expedia/www/haystack/metrics/ServoToInfluxDbViaGraphiteNamingConvention.java
@@ -7,6 +7,7 @@ import com.netflix.servo.publish.graphite.GraphiteNamingConvention;
 import com.netflix.servo.tag.Tag;
 import com.netflix.servo.tag.TagList;
 
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_APPLICATION;
 import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_CLASS;
 import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
 
@@ -17,7 +18,7 @@ import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_SUBSYSTEM;
  */
 public class ServoToInfluxDbViaGraphiteNamingConvention implements GraphiteNamingConvention {
     static final String MISSING_TAG = "MISSING_TAG_%s";
-    static final String METRIC_FORMAT = "%s.%s.%s.%s_%s";
+    static final String METRIC_FORMAT = "%s.%s.%s.%s.%s_%s";
     static final String STATISTIC_TAG_NAME = "statistic";
 
     private final String hostName;
@@ -48,6 +49,7 @@ public class ServoToInfluxDbViaGraphiteNamingConvention implements GraphiteNamin
         final MonitorConfig config = metric.getConfig();
         final TagList tags = config.getTags();
         final String subsystem = cleanup(tags, TAG_KEY_SUBSYSTEM);
+        final String application = cleanup(tags, TAG_KEY_APPLICATION);
         final String klass = cleanup(tags, TAG_KEY_CLASS);
         final String configName = config.getName(); // Servo disallows null for name, no need to cleanup
         final String type = cleanup(tags, DataSourceType.KEY);
@@ -56,7 +58,7 @@ public class ServoToInfluxDbViaGraphiteNamingConvention implements GraphiteNamin
         final Tag statisticTag = tags.getTag(STATISTIC_TAG_NAME);
         final String statisticName = statisticTag == null ? null : statisticTag.getValue();
         final String metricName = statisticName == null ? type : type + '_' + statisticName;
-        return String.format(METRIC_FORMAT, subsystem, hostName, klass, configName, metricName);
+        return String.format(METRIC_FORMAT, subsystem, application, hostName, klass, configName, metricName);
     }
 
     private static String cleanup(TagList tags, String name) {

--- a/commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 public class MetricObjectsTest {
     private final static Random RANDOM = new Random();
     private final static String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
+    private final static String APPLICATION = RANDOM.nextLong() + "APPLICATION";
     private final static String CLASS = RANDOM.nextLong() + "CLASS";
     private final static String METRIC_NAME = RANDOM.nextLong() + "METRIC_NAME";
 
@@ -63,7 +64,7 @@ public class MetricObjectsTest {
     public void testCreateAndRegisterCounter() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Counter counter = metricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS, METRIC_NAME);
+        final Counter counter = metricObjects.createAndRegisterCounter(SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME);
 
         assertsAndVerifiesForCreateAndRegisterCounter(counter);
     }
@@ -72,8 +73,9 @@ public class MetricObjectsTest {
     public void testCreateAndRegisterExistingCounter() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Counter counter = metricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS, METRIC_NAME);
-        final Counter existingCounter = metricObjects.createAndRegisterCounter(SUBSYSTEM, CLASS, METRIC_NAME);
+        final Counter counter = metricObjects.createAndRegisterCounter(SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME);
+        final Counter existingCounter = metricObjects.createAndRegisterCounter(
+                SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME);
 
         assertSame(counter, existingCounter);
         verify(mockLogger).warn(String.format(MetricObjects.COUNTER_ALREADY_REGISTERED, existingCounter));
@@ -81,7 +83,7 @@ public class MetricObjectsTest {
     }
 
     private void assertsAndVerifiesForCreateAndRegisterCounter(Counter counter) {
-        assertsAndVerifiesForCreateAndRegister(counter, 3);
+        assertsAndVerifiesForCreateAndRegister(counter, 4);
         final TagList tagList = counter.getConfig().getTags();
         assertEquals(DataSourceType.COUNTER.getValue(), tagList.getValue(DataSourceType.KEY));
     }
@@ -90,21 +92,24 @@ public class MetricObjectsTest {
     public void testCreateAndRegisterBasicTimer() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Timer timer = metricObjects.createAndRegisterBasicTimer(SUBSYSTEM, CLASS, METRIC_NAME, MILLISECONDS);
+        final Timer timer = metricObjects.createAndRegisterBasicTimer(
+                SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME, MILLISECONDS);
 
-        assertsAndVerifiesForCreateAndRegister(timer, 2);
+        assertsAndVerifiesForCreateAndRegister(timer, 3);
     }
 
     @Test
     public void testCreateAndRegisterExistingBasicTimer() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Timer timer = metricObjects.createAndRegisterBasicTimer(SUBSYSTEM, CLASS, METRIC_NAME, MILLISECONDS);
-        final Timer existingTimer = metricObjects.createAndRegisterBasicTimer(SUBSYSTEM, CLASS, METRIC_NAME, MILLISECONDS);
+        final Timer timer = metricObjects.createAndRegisterBasicTimer(
+                SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME, MILLISECONDS);
+        final Timer existingTimer = metricObjects.createAndRegisterBasicTimer(
+                SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME, MILLISECONDS);
 
         assertSame(timer, existingTimer);
         verify(mockLogger).warn(String.format(MetricObjects.TIMER_ALREADY_REGISTERED, existingTimer));
-        assertsAndVerifiesForCreateAndRegister(timer, 2);
+        assertsAndVerifiesForCreateAndRegister(timer, 3);
     }
 
     private void assertsAndVerifiesForCreateAndRegister(Monitor<?> monitor, int expectedTagListSize) {

--- a/commons/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static com.expedia.www.haystack.metrics.MetricPublishing.ASYNC_METRIC_OBSERVER_NAME;
+import static com.expedia.www.haystack.metrics.MetricPublishing.HOST_NAME_UNKNOWN_HOST_EXCEPTION;
 import static com.expedia.www.haystack.metrics.MetricPublishing.POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER;
 import static com.expedia.www.haystack.metrics.MetricPublishing.POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER;
 import static org.junit.Assert.assertEquals;
@@ -239,5 +240,15 @@ public class MetricPublishingTest {
     @Test
     public void testDefaultConstructor() {
         new MetricPublishing();
+    }
+
+    @Test
+    public void testFactoryGetLocalHostUnknownHostException() throws UnknownHostException {
+        when(mockFactory.getLocalHost()).thenThrow(new UnknownHostException());
+
+        final String localHostName = Factory.getLocalHostName(mockFactory);
+
+        assertEquals(HOST_NAME_UNKNOWN_HOST_EXCEPTION, localHostName);
+        verify(mockFactory).getLocalHost();
     }
 }

--- a/commons/src/test/java/com/expedia/www/haystack/metrics/ServoToInfluxDbViaGraphiteNamingConventionTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/metrics/ServoToInfluxDbViaGraphiteNamingConventionTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static com.expedia.www.haystack.metrics.MetricObjects.TAG_KEY_APPLICATION;
 import static com.expedia.www.haystack.metrics.ServoToInfluxDbViaGraphiteNamingConvention.METRIC_FORMAT;
 import static com.expedia.www.haystack.metrics.ServoToInfluxDbViaGraphiteNamingConvention.MISSING_TAG;
 import static com.expedia.www.haystack.metrics.ServoToInfluxDbViaGraphiteNamingConvention.STATISTIC_TAG_NAME;
@@ -30,6 +31,7 @@ public class ServoToInfluxDbViaGraphiteNamingConventionTest {
     private final static Random RANDOM = new Random();
     private final static String METRIC_NAME = RANDOM.nextLong() + "METRIC_NAME";
     private final static String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
+    private final static String APPLICATION = RANDOM.nextLong() + "APPLICATION";
     private final static String CLASS = RANDOM.nextLong() + "CLASS";
     private final static String TYPE = RANDOM.nextLong() + "TYPE";
     private final static String STATISTIC = RANDOM.nextLong() + "STATISTIC";
@@ -57,8 +59,10 @@ public class ServoToInfluxDbViaGraphiteNamingConventionTest {
 
         final String name = servoToInfluxDbViaGraphiteNamingConvention.getName(metric);
 
-        final String expected = String.format(METRIC_FORMAT, String.format(MISSING_TAG, TAG_KEY_SUBSYSTEM),
-                LOCAL_HOST_NAME_CLEANED, String.format(MISSING_TAG, TAG_KEY_CLASS), METRIC_NAME,
+        final String expected = String.format(METRIC_FORMAT,
+                String.format(MISSING_TAG, TAG_KEY_SUBSYSTEM),
+                String.format(MISSING_TAG, TAG_KEY_APPLICATION), LOCAL_HOST_NAME_CLEANED,
+                String.format(MISSING_TAG, TAG_KEY_CLASS), METRIC_NAME,
                 String.format(MISSING_TAG, DataSourceType.KEY));
         assertEquals(expected, name);
     }
@@ -67,19 +71,22 @@ public class ServoToInfluxDbViaGraphiteNamingConventionTest {
     public void testGetNameNoneNullWithoutStatistic() {
         final List<Tag> tagList = new ArrayList<>(3);
         tagList.add(Tags.newTag(TAG_KEY_SUBSYSTEM, SUBSYSTEM));
+        tagList.add(Tags.newTag(TAG_KEY_APPLICATION, APPLICATION));
         tagList.add(Tags.newTag(TAG_KEY_CLASS, CLASS));
         tagList.add(Tags.newTag(DataSourceType.KEY, TYPE));
         final Metric metric = new Metric(METRIC_NAME, new BasicTagList(tagList), 0, 0);
 
         final String name = servoToInfluxDbViaGraphiteNamingConvention.getName(metric);
 
-        assertEquals(String.format(METRIC_FORMAT, SUBSYSTEM, LOCAL_HOST_NAME_CLEANED, CLASS, METRIC_NAME, TYPE), name);
+        assertEquals(String.format(
+                METRIC_FORMAT, SUBSYSTEM, APPLICATION, LOCAL_HOST_NAME_CLEANED, CLASS, METRIC_NAME, TYPE), name);
     }
 
     @Test
     public void testGetNameNoneNullWithStatistic() {
-        final List<Tag> tagList = new ArrayList<>(4);
+        final List<Tag> tagList = new ArrayList<>(5);
         tagList.add(Tags.newTag(TAG_KEY_SUBSYSTEM, SUBSYSTEM));
+        tagList.add(Tags.newTag(TAG_KEY_APPLICATION, APPLICATION));
         tagList.add(Tags.newTag(TAG_KEY_CLASS, CLASS));
         tagList.add(Tags.newTag(DataSourceType.KEY, TYPE));
         tagList.add(Tags.newTag(STATISTIC_TAG_NAME, STATISTIC));
@@ -88,7 +95,7 @@ public class ServoToInfluxDbViaGraphiteNamingConventionTest {
         final String name = servoToInfluxDbViaGraphiteNamingConvention.getName(metric);
 
         final String expected = String.format(METRIC_FORMAT,
-                SUBSYSTEM, LOCAL_HOST_NAME_CLEANED, CLASS, METRIC_NAME, TYPE + '_' + STATISTIC);
+                SUBSYSTEM, APPLICATION, LOCAL_HOST_NAME_CLEANED, CLASS, METRIC_NAME, TYPE + '_' + STATISTIC);
         assertEquals(expected, name);
     }
 }

--- a/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
+++ b/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
@@ -88,7 +88,7 @@ data:
       separator = "."
       udp-read-buffer = 0
       templates = [
-       "haystack.* system.subsystem.server.class.measurement*",
+       "haystack.* system.subsystem.application.server.class.measurement*",
       ]
 
     [[collectd]]


### PR DESCRIPTION
Bring back test coverage to 100%.
Remove some JavaDoc comments from the Factory objects, which are no
longer public and therefore do not show up on generated JavaDoc.