### PR TITLE
Add InfluxDb template for metrics from the custom log4j appender

### DIFF
--- a/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
+++ b/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
@@ -88,7 +88,8 @@ data:
       separator = "."
       udp-read-buffer = 0
       templates = [
-       "haystack.* system.subsystem.application.server.class.measurement*",
+       "haystack.errors.* system.subsystem.fqClass.server.lineNumber.measurement*",
+       "haystack.*        system.subsystem.application.server.class.measurement*",
       ]
 
     [[collectd]]


### PR DESCRIPTION
soon to come in the haystack-log4j-metrics-appender package