### PR TITLE
Fix influxdb.yaml to reflect the new metric in which the subsystem is

### DIFF
--- a/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
+++ b/deployment/k8s/addons/1.6/monitoring/influxdb.yaml
@@ -88,7 +88,7 @@ data:
       separator = "."
       udp-read-buffer = 0
       templates = [
-       "haystack.errors.* system.subsystem.fqClass.host.lineNumber.measurement*",
+       "haystack.errors.* system.metricGroup.subsystem.fqClass.host.lineNumber.measurement*",
        "haystack.*        system.subsystem.application.host.class.measurement*",
       ]
 

--- a/deployment/terraform/modules/k8s-addons/monitoring/influxdb/templates/influxdb-yaml.tpl
+++ b/deployment/terraform/modules/k8s-addons/monitoring/influxdb/templates/influxdb-yaml.tpl
@@ -88,7 +88,7 @@ data:
       separator = "."
       udp-read-buffer = 0
       templates = [
-       "haystack.errors.* system.subsystem.fqClass.host.lineNumber.measurement*",
+       "haystack.errors.* system.metricGroup.subsystem.fqClass.host.lineNumber.measurement*",
        "haystack.*        system.subsystem.application.host.class.measurement*",
       ]
 


### PR DESCRIPTION
separate from the fully qualified class name.