### PR TITLE
remove the "ignores IP secrets for particular service(s)" setting that

### DIFF
--- a/deployment/terraform/cluster/aws/apps/main.tf
+++ b/deployment/terraform/cluster/aws/apps/main.tf
@@ -44,7 +44,6 @@ module "haystack-apps" {
   pipes_secret_detector_secretsnotifications_email_host = "${var.pipes_secret_detector_secretsnotifications_email_host}"
   pipes_secret_detector_secretsnotifications_email_subject = "${var.pipes_secret_detector_secretsnotifications_email_subject}"
   pipes_secret_detector_secretsnotifications_email_tos = "${var.pipes_secret_detector_secretsnotifications_email_tos}"
-  pipes_secret_detector_secretsnotifications_ignores_ips_servicenames = "${var.pipes_secret_detector_secretsnotifications_ignores_ips_servicenames}"
   pipes_version = "${var.pipes_version}"
 
   traces_enabled = "${var.traces_enabled}"

--- a/deployment/terraform/cluster/aws/apps/variables.tf
+++ b/deployment/terraform/cluster/aws/apps/variables.tf
@@ -86,7 +86,6 @@ variable "pipes_secret_detector_secretsnotifications_email_from" { default = "" 
 variable "pipes_secret_detector_secretsnotifications_email_host" { default = "" }
 variable "pipes_secret_detector_secretsnotifications_email_subject" { default = "" }
 variable "pipes_secret_detector_secretsnotifications_email_tos" { default = "" }
-variable "pipes_secret_detector_secretsnotifications_ignores_ips_servicenames" { default = "" }
 variable "pipes_version" { default = "d38d528d88210107c26a173ead045bcc16c632ef" }
 
 # collectors config

--- a/deployment/terraform/cluster/local/apps/main.tf
+++ b/deployment/terraform/cluster/local/apps/main.tf
@@ -57,7 +57,6 @@ module "haystack-apps" {
   pipes_secret_detector_secretsnotifications_email_host = "${var.pipes_secret_detector_secretsnotifications_email_host}"
   pipes_secret_detector_secretsnotifications_email_subject = "${var.pipes_secret_detector_secretsnotifications_email_subject}"
   pipes_secret_detector_secretsnotifications_email_tos = "${var.pipes_secret_detector_secretsnotifications_email_tos}"
-  pipes_secret_detector_secretsnotifications_ignores_ips_servicenames = "${var.pipes_secret_detector_secretsnotifications_ignores_ips_servicenames}"
   pipes_version = "${var.pipes_version}"
 
   #trace configuration_overrides

--- a/deployment/terraform/cluster/local/apps/variables.tf
+++ b/deployment/terraform/cluster/local/apps/variables.tf
@@ -83,7 +83,6 @@ variable "pipes_secret_detector_secretsnotifications_email_from" { default = "" 
 variable "pipes_secret_detector_secretsnotifications_email_host" { default = "" }
 variable "pipes_secret_detector_secretsnotifications_email_subject" { default = "" }
 variable "pipes_secret_detector_secretsnotifications_email_tos" { default = "" }
-variable "pipes_secret_detector_secretsnotifications_ignores_ips_servicenames" { default = "" }
 variable "pipes_version" { default = "f48a026554636555fc3cb20ac760e4315857f949" }
 
 # collectors config

--- a/deployment/terraform/modules/haystack-apps/kubernetes/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/main.tf
@@ -198,7 +198,6 @@ module "pipes-secret-detector" {
   pipes_secret_detector_secretsnotifications_email_host = "${var.pipes_secret_detector_secretsnotifications_email_host}"
   pipes_secret_detector_secretsnotifications_email_subject = "${var.pipes_secret_detector_secretsnotifications_email_subject}"
   pipes_secret_detector_secretsnotifications_email_tos = "${var.pipes_secret_detector_secretsnotifications_email_tos}"
-  pipes_secret_detector_secretsnotifications_ignores_ips_servicenames = "${var.pipes_secret_detector_secretsnotifications_ignores_ips_servicenames}"
   replicas = "${var.pipes_secret_detector_instances}"
   source = "pipes-secret-detector"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes-secret-detector/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes-secret-detector/main.tf
@@ -22,7 +22,6 @@ data "template_file" "deployment_yaml" {
     pipes_secret_detector_secretsnotifications_email_host = "${var.pipes_secret_detector_secretsnotifications_email_host}"
     pipes_secret_detector_secretsnotifications_email_subject = "${var.pipes_secret_detector_secretsnotifications_email_subject}"
     pipes_secret_detector_secretsnotifications_email_tos = "${var.pipes_secret_detector_secretsnotifications_email_tos}"
-    pipes_secret_detector_secretsnotifications_ignores_ips_servicenames = "${var.pipes_secret_detector_secretsnotifications_ignores_ips_servicenames}"
     replicas = "${var.replicas}"
   }
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes-secret-detector/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes-secret-detector/templates/deployment_yaml.tpl
@@ -42,8 +42,6 @@ spec:
           value: "${pipes_secret_detector_secretsnotifications_email_subject}"
         - name: "HAYSTACK_SECRETSNOTIFICATION_EMAIL_TOS"
           value: "${pipes_secret_detector_secretsnotifications_email_tos}"
-        - name: "HAYSTACK_SECRETSNOTIFICATION_IGNORES_IPS_SERVICENAMES"
-          value: "${pipes_secret_detector_secretsnotifications_ignores_ips_servicenames}"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes-secret-detector/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes-secret-detector/variables.tf
@@ -9,7 +9,6 @@ variable "pipes_secret_detector_secretsnotifications_email_from" {}
 variable "pipes_secret_detector_secretsnotifications_email_host" {}
 variable "pipes_secret_detector_secretsnotifications_email_subject" {}
 variable "pipes_secret_detector_secretsnotifications_email_tos" {}
-variable "pipes_secret_detector_secretsnotifications_ignores_ips_servicenames" {}
 
 variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}

--- a/deployment/terraform/modules/haystack-apps/kubernetes/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/variables.tf
@@ -62,7 +62,6 @@ variable "pipes_secret_detector_secretsnotifications_email_from" {}
 variable "pipes_secret_detector_secretsnotifications_email_host" {}
 variable "pipes_secret_detector_secretsnotifications_email_subject" {}
 variable "pipes_secret_detector_secretsnotifications_email_tos" {}
-variable "pipes_secret_detector_secretsnotifications_ignores_ips_servicenames" {}
 variable "pipes_version" {}
 
 


### PR DESCRIPTION
was just added; it's too much work to get the Span plumbed down to the
Finder to examine operation name.