### PR TITLE
overriding default jmx settings for haystack apps

### DIFF
--- a/deployment/terraform/cluster/aws/apps/main.tf
+++ b/deployment/terraform/cluster/aws/apps/main.tf
@@ -1,7 +1,8 @@
 locals {
   app-node_selecter_label = "kops.k8s.io/instancegroup: app-nodes"
   default_cpu_limit = "500m"
-  default_memory_limit = "1500Mi"
+  default_memory_limit = "1500"
+  jvm_memory_limit = "1024"
   //always setting to true for aws deployment
   graphite_enabled = "true"
 }
@@ -20,6 +21,7 @@ module "haystack-apps" {
   haystack_cluster_name = "${var.haystack_cluster_name}"
   default_cpu_limit = "${local.default_cpu_limit}"
   default_memory_limit = "${local.default_memory_limit}"
+  jvm_memory_limit = "${local.jvm_memory_limit}"
   app-node_selector_label = "${local.app-node_selecter_label}"
   kubectl_executable_name = "${var.kubectl_executable_name}"
 

--- a/deployment/terraform/cluster/local/apps/main.tf
+++ b/deployment/terraform/cluster/local/apps/main.tf
@@ -1,7 +1,8 @@
 locals {
   app-node_selecter_label = "kubernetes.io/hostname: minikube"
   default_cpu_limit = "100m"
-  default_memory_limit = "250Mi"
+  default_memory_limit = "250"
+  jvm_memory_limit = "200"
 }
 
 data "terraform_remote_state" "haystack_inrastructure" {
@@ -15,6 +16,7 @@ module "haystack-apps" {
 
   default_cpu_limit = "${local.default_cpu_limit}"
   default_memory_limit = "${local.default_memory_limit}"
+  jvm_memory_limit = "${local.jvm_memory_limit}"
   elasticsearch_hostname = "${data.terraform_remote_state.haystack_inrastructure.elasticsearch_hostname}"
   elasticsearch_port = "${data.terraform_remote_state.haystack_inrastructure.elasticsearch_port}"
   kubectl_context_name = "${data.terraform_remote_state.haystack_inrastructure.k8s_cluster_name}"

--- a/deployment/terraform/cluster/local/infrastructure/main.tf
+++ b/deployment/terraform/cluster/local/infrastructure/main.tf
@@ -9,6 +9,7 @@ locals {
   app-node_selecter_label = "kubernetes.io/hostname: minikube"
   default_cpu_limit = "100m"
   memory_limit_in_mb = "400"
+  jvm_memory_limit = "250"
   k8s_datastores_heap_memory_in_mb = "1024"
 }
 module "k8s-addons" {
@@ -46,5 +47,5 @@ module "haystack-infrastructure" {
   kubectl_executable_name = "${var.kubectl_executable_name}"
   cpu_limit = "${local.default_cpu_limit}"
   memory_limit = "${local.memory_limit_in_mb}"
-
+  jvm_memory_limit = "${local.jvm_memory_limit}"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/collectors/kinesis-span-collector/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/collectors/kinesis-span-collector/main.tf
@@ -42,9 +42,10 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     configmap_name = "${local.configmap_name}"
-    env_vars= "${indent(9,"${var.env_vars}")}"
+    env_vars = "${indent(9,"${var.env_vars}")}"
 
   }
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/collectors/kinesis-span-collector/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/collectors/kinesis-span-collector/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/kinesis-span-collector.conf"
@@ -38,6 +38,10 @@ spec:
           value: "${graphite_host}"
         - name: "HAYSTACK_GRAPHITE_PORT"
           value: "${graphite_port}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/collectors/kinesis-span-collector/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/collectors/kinesis-span-collector/variables.tf
@@ -12,6 +12,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 

--- a/deployment/terraform/modules/haystack-apps/kubernetes/collectors/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/collectors/main.tf
@@ -18,4 +18,5 @@ module "kinesis-span-collector" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/collectors/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/collectors/variables.tf
@@ -11,6 +11,7 @@ variable "node_selector_label"{}
 
 variable "default_memory_limit"{}
 variable "default_cpu_limit"{}
+variable "jvm_memory_limit"{}
 
 # collectors config
 variable "collector" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/main.tf
@@ -1,3 +1,7 @@
+locals {
+
+}
+
 module "traces" {
   source = "traces"
   namespace = "${var.k8s_app_namespace}"
@@ -15,6 +19,7 @@ module "traces" {
   kubectl_context_name = "${var.kubectl_context_name}"
   default_cpu_limit = "${var.default_cpu_limit}"
   default_memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   traces = "${var.traces}"
 }
 
@@ -24,6 +29,7 @@ module "trends" {
   kubectl_context_name = "${var.kubectl_context_name}"
   kubectl_executable_name = "${var.kubectl_executable_name}"
   default_memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   default_cpu_limit = "${var.default_cpu_limit}"
   node_selector_label = "${var.app-node_selector_label}"
 
@@ -44,6 +50,7 @@ module "pipes" {
   kubectl_context_name = "${var.kubectl_context_name}"
   kubectl_executable_name = "${var.kubectl_executable_name}"
   default_memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   default_cpu_limit = "${var.default_cpu_limit}"
   node_selector_label = "${var.app-node_selector_label}"
   haystack_cluster_name = "${var.haystack_cluster_name}"
@@ -63,6 +70,7 @@ module "collectors" {
   kubectl_context_name = "${var.kubectl_context_name}"
   kubectl_executable_name = "${var.kubectl_executable_name}"
   default_memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   default_cpu_limit = "${var.default_cpu_limit}"
   node_selector_label = "${var.app-node_selector_label}"
   haystack_cluster_name = "${var.haystack_cluster_name}"
@@ -87,6 +95,7 @@ module "service-graph" {
   kubectl_context_name = "${var.kubectl_context_name}"
   default_cpu_limit = "${var.default_cpu_limit}"
   default_memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   service-graph = "${var.service-graph}"
 }
 

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/main.tf
@@ -12,6 +12,7 @@ module "pipes-json-transformer" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.pipes["json_transformer_environment_overrides"]}"
 
 }
@@ -30,6 +31,7 @@ module "pipes-kafka-producer" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.pipes["kafka_producer_environment_overrides"]}"
 
 }
@@ -51,6 +53,7 @@ module "pipes-http-poster" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.pipes["http_poster_environment_overrides"]}"
 }
 
@@ -74,6 +77,7 @@ module "pipes-firehose-writer" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.pipes["firehose_writer_environment_overrides"]}"
 }
 
@@ -88,6 +92,7 @@ module "pipes-secret-detector" {
   kubectl_context_name = "${var.kubectl_context_name}"
   kubectl_executable_name = "${var.kubectl_executable_name}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   namespace = "${var.app_namespace}"
   node_selecter_label = "${var.node_selector_label}"
   pipes_secret_detector_kafka_threadcount = "${var.pipes["pipes_secret_detector_kafka_threadcount"]}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-firehose-writer/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-firehose-writer/main.tf
@@ -21,6 +21,7 @@ data "template_file" "deployment_yaml" {
     replicas = "${var.replicas}"
     image = "${var.image}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     graphite_host = "${var.graphite_hostname}"
     graphite_port = "${var.graphite_port}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-firehose-writer/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-firehose-writer/templates/deployment_yaml.tpl
@@ -23,10 +23,10 @@ spec:
         image: ${image}
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_FIREHOSE_INITIALRETRYSLEEP"
           value: "${firehose_initialretrysleep}"
@@ -50,6 +50,10 @@ spec:
           value: "${firehose_usestringbuffering}"
         - name: "HAYSTACK_FIREHOSE_MAXBATCHINTERVAL"
           value: "${firehose_maxbatchinterval}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-firehose-writer/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-firehose-writer/variables.tf
@@ -16,6 +16,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-http-poster/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-http-poster/main.tf
@@ -18,6 +18,7 @@ data "template_file" "deployment_yaml" {
     replicas = "${var.replicas}"
     image = "${var.image}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     graphite_host = "${var.graphite_hostname}"
     graphite_port = "${var.graphite_port}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-http-poster/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-http-poster/templates/deployment_yaml.tpl
@@ -23,10 +23,10 @@ spec:
         image: ${image}
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_HTTPPOST_POLLPERCENT"
           value: "${http_poster_httppost_pollpercent}"
@@ -38,6 +38,10 @@ spec:
           value: "${graphite_host}"
         - name: "HAYSTACK_GRAPHITE_PORT"
           value: "${graphite_port}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
       nodeSelector:
         ${node_selecter_label}

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-http-poster/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-http-poster/variables.tf
@@ -12,6 +12,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-json-transformer/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-json-transformer/main.tf
@@ -15,6 +15,7 @@ data "template_file" "deployment_yaml" {
     replicas = "${var.replicas}"
     image = "${var.image}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     graphite_host = "${var.graphite_hostname}"
     graphite_port = "${var.graphite_port}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-json-transformer/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-json-transformer/templates/deployment_yaml.tpl
@@ -23,10 +23,10 @@ spec:
         image: ${image}
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_KAFKA_BROKERS"
           value: "${kafka_hostname}"
@@ -34,6 +34,10 @@ spec:
           value: "${graphite_host}"
         - name: "HAYSTACK_GRAPHITE_PORT"
           value: "${graphite_port}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
       nodeSelector:
         ${node_selecter_label}

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-json-transformer/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-json-transformer/variables.tf
@@ -10,6 +10,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-kafka-producer/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-kafka-producer/main.tf
@@ -12,6 +12,7 @@ data "template_file" "deployment_yaml" {
     namespace = "${var.namespace}"
     kafka_hostname = "${var.kafka_hostname}"
     node_selecter_label = "${var.node_selecter_label}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     replicas = "${var.replicas}"
     image = "${var.image}"
     memory_limit = "${var.memory_limit}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-kafka-producer/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-kafka-producer/templates/deployment_yaml.tpl
@@ -23,10 +23,10 @@ spec:
         image: ${image}
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_KAFKA_BROKERS"
           value: "${kafka_hostname}"
@@ -34,6 +34,10 @@ spec:
           value: "${graphite_host}"
         - name: "HAYSTACK_GRAPHITE_PORT"
           value: "${graphite_port}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
       nodeSelector:
         ${node_selecter_label}

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-kafka-producer/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-kafka-producer/variables.tf
@@ -10,6 +10,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-secret-detector/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-secret-detector/main.tf
@@ -16,6 +16,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     kafka_hostname = "${var.kafka_hostname}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     namespace = "${var.namespace}"
     node_selecter_label = "${var.node_selecter_label}"
     pipes_secret_detector_secretsnotifications_email_from = "${var.pipes_secret_detector_secretsnotifications_email_from}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-secret-detector/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-secret-detector/templates/deployment_yaml.tpl
@@ -23,10 +23,10 @@ spec:
         image: ${image}
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_GRAPHITE_HOST"
           value: "${graphite_host}"
@@ -46,6 +46,10 @@ spec:
           value: "${pipes_secret_detector_secretsnotifications_email_tos}"
         - name: "HAYSTACK_SECRETSNOTIFICATIONS_WHITELIST_BUCKET"
           value: "${pipes_secret_detector_secretsnotifications_whitelist_bucket}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-secret-detector/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/pipes-secret-detector/variables.tf
@@ -16,6 +16,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/pipes/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/pipes/variables.tf
@@ -10,7 +10,7 @@ variable "node_selector_label"{}
 
 variable "default_memory_limit"{}
 variable "default_cpu_limit"{}
-
+variable "jvm_memory_limit"{}
 # pipes config
 variable "pipes" {
   type = "map"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/main.tf
@@ -37,6 +37,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     configmap_name = "${local.configmap_name}"
     env_vars= "${indent(9,"${var.env_vars}")}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/graph-builder.conf"
@@ -42,6 +42,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
       nodeSelector:
         ${node_selecter_label}

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/variables.tf
@@ -9,6 +9,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/main.tf
@@ -12,6 +12,7 @@ module "node-finder" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.service-graph["node_finder_environment_overrides"]}"
 }
 
@@ -29,5 +30,6 @@ module "graph-builder" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.service-graph["graph_builder_environment_overrides"]}"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/node-finder/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/node-finder/main.tf
@@ -37,6 +37,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     configmap_name = "${local.configmap_name}"
     env_vars= "${indent(9,"${var.env_vars}")}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/node-finder/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/node-finder/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/node-finder.conf"
@@ -38,6 +38,10 @@ spec:
           value: "${graphite_host}"
         - name: "HAYSTACK_GRAPHITE_PORT"
           value: "${graphite_port}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/node-finder/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/node-finder/variables.tf
@@ -9,6 +9,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/variables.tf
@@ -7,6 +7,7 @@ variable "kubectl_executable_name" {}
 variable "namespace" {}
 variable "node_selector_label"{}
 variable "default_memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "default_cpu_limit"{}
 
 # service-graph config

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/main.tf
@@ -16,6 +16,7 @@ module "trace-indexer" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.traces["trace_indexer_environment_overrides"]}"
 }
 
@@ -35,5 +36,6 @@ module "trace-reader" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.traces["trace_reader_environment_overrides"]}"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-indexer/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-indexer/main.tf
@@ -43,6 +43,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     configmap_name = "${local.configmap_name}"
     env_vars= "${indent(9,"${var.env_vars}")}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-indexer/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-indexer/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/trace-indexer.conf"
@@ -40,6 +40,10 @@ spec:
           value: "${graphite_port}"
         - name: "HAYSTACK_GRAPHITE_ENABLED"
           value: "${graphite_enabled}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-indexer/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-indexer/variables.tf
@@ -13,6 +13,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "enable_kafka_sink" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-reader/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-reader/main.tf
@@ -40,6 +40,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     service_port = "${var.service_port}"
     container_port = "${var.container_port}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-reader/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-reader/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         livenessProbe:
           exec:
             command:
@@ -49,6 +49,10 @@ spec:
           value: "${graphite_port}"
         - name: "HAYSTACK_GRAPHITE_ENABLED"
           value: "${graphite_enabled}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-reader/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/trace-reader/variables.tf
@@ -12,6 +12,7 @@ variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
 variable "cpu_limit"{}
+variable "jvm_memory_limit"{}
 variable "env_vars" {}
 
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/traces/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/traces/variables.tf
@@ -13,6 +13,7 @@ variable "namespace" {}
 variable "node_selector_label"{}
 
 variable "default_memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "default_cpu_limit"{}
 
 # traces config

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/main.tf
@@ -35,6 +35,7 @@ module "span-timeseries-transformer" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.trends["span_timeseries_transformer_environment_overrides"]}"
 }
 module "timeseries-aggregator" {
@@ -54,5 +55,6 @@ module "timeseries-aggregator" {
   kubectl_context_name = "${var.kubectl_context_name}"
   cpu_limit = "${var.default_cpu_limit}"
   memory_limit = "${var.default_memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   env_vars = "${var.trends["timeseries_aggregator_environment_overrides"]}"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/span-timeseries-transformer/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/span-timeseries-transformer/main.tf
@@ -41,6 +41,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     configmap_name = "${local.configmap_name}"
     env_vars= "${indent(9,"${var.env_vars}")}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/span-timeseries-transformer/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/span-timeseries-transformer/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/span-timeseries-transformer.conf"
@@ -40,6 +40,10 @@ spec:
           value: "${graphite_port}"
         - name: "HAYSTACK_GRAPHITE_ENABLED"
           value: "${graphite_enabled}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/span-timeseries-transformer/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/span-timeseries-transformer/variables.tf
@@ -12,6 +12,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "env_vars" {}
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/timeseries-aggregator/main.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/timeseries-aggregator/main.tf
@@ -44,6 +44,7 @@ data "template_file" "deployment_yaml" {
     image = "${var.image}"
     replicas = "${var.replicas}"
     memory_limit = "${var.memory_limit}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     configmap_name = "${local.configmap_name}"
     env_vars= "${indent(9,"${var.env_vars}")}"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/timeseries-aggregator/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/timeseries-aggregator/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/timeseries-aggregator.conf"
@@ -40,6 +40,10 @@ spec:
           value: "${graphite_port}"
         - name: "HAYSTACK_GRAPHITE_ENABLED"
           value: "${graphite_enabled}"
+        - name: "JAVA_XMS"
+          value: "${jvm_memory_limit}m"
+        - name: "JAVA_XMX"
+          value: "${jvm_memory_limit}m"
         ${env_vars}
         livenessProbe:
           exec:

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/timeseries-aggregator/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/timeseries-aggregator/variables.tf
@@ -15,6 +15,8 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label" {}
 variable "memory_limit" {}
+variable "jvm_memory_limit"{}
+
 variable "cpu_limit" {}
 
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-apps/kubernetes/trends/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/trends/variables.tf
@@ -12,6 +12,7 @@ variable "app_namespace" {}
 variable "node_selector_label"{}
 
 variable "default_memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "default_cpu_limit"{}
 
 # trends config

--- a/deployment/terraform/modules/haystack-apps/kubernetes/ui/templates/deployment_yaml.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/ui/templates/deployment_yaml.tpl
@@ -27,10 +27,10 @@ spec:
           name: config-volume
         resources:
           limits:
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
           requests:
             cpu: ${cpu_limit}
-            memory: ${memory_limit}
+            memory: ${memory_limit}Mi
         env:
         - name: "HAYSTACK_OVERRIDES_CONFIG_PATH"
           value: "/config/haystack-ui.json"

--- a/deployment/terraform/modules/haystack-apps/kubernetes/variables.tf
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/variables.tf
@@ -14,6 +14,7 @@ variable "k8s_app_namespace" {}
 variable "app-node_selector_label"{}
 
 variable "default_memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "default_cpu_limit"{}
 
 # traces config

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/cassandra/variables.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/cassandra/variables.tf
@@ -4,6 +4,8 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
+
 variable "cpu_limit"{}
 
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/elasticsearch/main.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/elasticsearch/main.tf
@@ -15,7 +15,7 @@ data "template_file" "deployment_yaml" {
     replicas = "${var.replicas}"
     image = "${local.es_docker_image}"
     memory_limit = "${var.memory_limit}"
-    jvm_memory_limit = "${var.memory_limit - 200}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     cpu_limit = "${var.cpu_limit}"
     service_port = "${local.service_port}"
     container_port = "${local.container_port}"

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/elasticsearch/variables.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/elasticsearch/variables.tf
@@ -3,6 +3,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 variable "namespace" {}
 

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/main.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/main.tf
@@ -15,6 +15,7 @@ module "zookeeper" {
   kubectl_context_name = "${var.kubectl_context_name}"
   node_selecter_label = "${var.node_selecter_label}"
   memory_limit = "${var.memory_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
   cpu_limit = "${var.cpu_limit}"
 }
 
@@ -29,7 +30,7 @@ data "template_file" "deployment_yaml" {
     image = "${local.image}"
     memory_limit = "${var.memory_limit}"
     cpu_limit = "${var.cpu_limit}"
-    jvm_memory_limit = "${var.memory_limit - 200}"
+    jvm_memory_limit = "${var.jvm_memory_limit}"
     service_port = "${local.service_port}"
     container_port = "${local.container_port}"
     host_name = "${var.docker_host_ip}"

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/variables.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/variables.tf
@@ -4,6 +4,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label" {}
 variable "memory_limit" {}
+variable "jvm_memory_limit"{}
 variable "cpu_limit" {}
 variable "docker_host_ip" {
   default = "192.168.99.100"

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/zookeeper/variables.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/zookeeper/variables.tf
@@ -4,6 +4,7 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}
 
 variable "termination_grace_period" {

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/main.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/main.tf
@@ -7,6 +7,7 @@ module "cassandra" {
   node_selecter_label = "${var.node_selecter_label}"
   memory_limit = "${var.memory_limit}"
   cpu_limit = "${var.cpu_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
 }
 
 module "es" {
@@ -18,6 +19,7 @@ module "es" {
   node_selecter_label = "${var.node_selecter_label}"
   memory_limit = "${var.memory_limit}"
   cpu_limit = "${var.cpu_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
 }
 
 
@@ -31,4 +33,5 @@ module "kafka" {
   node_selecter_label = "${var.node_selecter_label}"
   memory_limit = "${var.memory_limit}"
   cpu_limit = "${var.cpu_limit}"
+  jvm_memory_limit = "${var.jvm_memory_limit}"
 }

--- a/deployment/terraform/modules/haystack-datastores/kubernetes/variables.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/variables.tf
@@ -4,4 +4,5 @@ variable "kubectl_executable_name" {}
 variable "kubectl_context_name" {}
 variable "node_selecter_label"{}
 variable "memory_limit"{}
+variable "jvm_memory_limit"{}
 variable "cpu_limit"{}


### PR DESCRIPTION
The haystack apps have a default XMX value configured as 1024Mb in the docker images, this needs to be overridden in the local mode to avoid potential out of memory issues. 