### PR TITLE
Renaming topics, step 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 .DS_Store
 .node_modules
+haystack.iml
 target/
 deployment/k8s/third_party_softwares/
 deployment/terraform/cluster/local/apps/overrides.json
@@ -21,5 +22,3 @@ docsite/translated_docs
 docsite/build/
 docsite/yarn.lock
 fakespans
-
-

--- a/deployment/terraform/modules/haystack-apps/kubernetes/alerting/anomaly-validator/templates/anomaly-validator_conf.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/alerting/anomaly-validator/templates/anomaly-validator_conf.tpl
@@ -7,9 +7,12 @@ anomaly-validator {
       default.value.serde = "com.expedia.adaptivealerting.kafka.serde.JsonPojoSerde"
       JsonPojoClass = "com.expedia.adaptivealerting.core.anomaly.AnomalyResult"
     }
+
+    # TODO Renaming "topic" to "inbound-topic". Remove topic once transition is complete. [WLW]
     topic = "anomalies"
+    inbound-topic = "anomalies"
+
     investigation {
       endpoint = "${investigation_endpoint}"
     }
 }
-

--- a/deployment/terraform/modules/haystack-apps/kubernetes/alerting/constant-detector/templates/constant-detector_conf.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/alerting/constant-detector/templates/constant-detector_conf.tpl
@@ -5,6 +5,8 @@ constant-detector {
     application.id = "constant-detector"
     bootstrap.servers = "${kafka_endpoint}"
   }
-  topic = "constant-metrics"
 
+  # TODO Renaming "topic" to "inbound-topic". Remove topic once transition is complete. [WLW]
+  topic = "constant-metrics"
+  inbound-topic = "constant-metrics"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/alerting/ewma-detector/templates/ewma-detector_conf.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/alerting/ewma-detector/templates/ewma-detector_conf.tpl
@@ -5,6 +5,8 @@ ewma-detector {
     application.id = "ewma-detector"
     bootstrap.servers = "${kafka_endpoint}"
   }
-  topic = "ewma-metrics"
 
+  # TODO Renaming "topic" to "inbound-topic". Remove topic once transition is complete. [WLW]
+  topic = "ewma-metrics"
+  inbound-topic = "ewma-metrics"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/alerting/metric-router/templates/metric-router_conf.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/alerting/metric-router/templates/metric-router_conf.tpl
@@ -6,5 +6,8 @@ metric-router {
     application.id = "metric-router"
     bootstrap.servers = "${kafka_endpoint}"
   }
+
+  # TODO Renaming "topic" to "inbound-topic". Remove topic once transition is complete. [WLW]
   topic = "mdm"
+  inbound-topic = "mdm"
 }

--- a/deployment/terraform/modules/haystack-apps/kubernetes/alerting/pewma-detector/templates/pewma-detector_conf.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/alerting/pewma-detector/templates/pewma-detector_conf.tpl
@@ -5,6 +5,8 @@ pewma-detector {
     application.id = "pewma-detector"
     bootstrap.servers = "${kafka_endpoint}"
   }
-  topic = "pewma-metrics"
 
+  # TODO Renaming "topic" to "inbound-topic". Remove topic once transition is complete. [WLW]
+  topic = "pewma-metrics"
+  inbound-topic = "pewma-metrics"
 }


### PR DESCRIPTION
In this commit I'm creating parallel properties called "inbound-topic" to
clarify that this is the inbound topic rather than the outbound. Once we
migrate the software over to using inbound-topic, we can remove the topic
property altogether.