### PR TITLE
Change zookeeper image to use the one from official docker repo

### DIFF
--- a/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/zookeeper/main.tf
+++ b/deployment/terraform/modules/haystack-datastores/kubernetes/kafka/zookeeper/main.tf
@@ -3,7 +3,7 @@ locals {
   service_port = 2181
   container_port = 2181
   deployment_yaml_file_path = "${path.module}/templates/deployment-yaml.tpl"
-  image = "wurstmeister/zookeeper:3.4.6"
+  image = "zookeeper:3.4.12"
 }
 
 data "template_file" "deployment_yaml" {


### PR DESCRIPTION
Replacing wurstmeister's with the one from the official docker repo.
Also updated to version 3.4.6 which was over 2 years old to 3.4.12.
This image is 146MB compared to 451MB for the previous one.