### PR TITLE
Set replication factor to 1 for graph builder (local k8s deployments)

### DIFF
--- a/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/templates/graph-builder_conf.tpl
+++ b/deployment/terraform/modules/haystack-apps/kubernetes/service-graph/graph-builder/templates/graph-builder_conf.tpl
@@ -11,6 +11,7 @@ kafka {
     commit.interval.ms = 3000
     auto.offset.reset = latest
     timestamp.extractor = "org.apache.kafka.streams.processor.WallclockTimestampExtractor"
+    replication.factor = 1
   }
 
   consumer {


### PR DESCRIPTION
As per https://github.com/ExpediaDotCom/haystack-service-graph/blob/master/graph-builder/src/main/resources/app.conf#L14 the graph builder is using replication factor = 2, however for local deployments there is only one broker and the creation of the topic fails with

`org.apache.kafka.streams.errors.StreamsException: Could not create topic haystack-service-graph-graph-builder-service-graph-changelog.\n at org.apache.kafka.streams.processor.internals.InternalTopicManager.makeReady(InternalTopicManager.java:137) (...) java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 2 larger than available brokers: 1`