### PR TITLE
All "-input=false" to the AUTO_APPROVE variable in the installCompone…

### DIFF
--- a/deployment/terraform/apply-compose.sh
+++ b/deployment/terraform/apply-compose.sh
@@ -244,7 +244,7 @@ function installComponents() {
 
     cd $DIR/cluster/$CLUSTER_TYPE/apps
     if [ "$SKIP_APPROVAL" = "true" ]; then
-        AUTO_APPROVE="-auto-approve"
+        AUTO_APPROVE="-input=false -auto-approve"
     else
         echo "$SKIP_APPROVAL"
     fi


### PR DESCRIPTION
…nts()

function; we're attempting to make test deployment work properly and this
seems like a small change that is easy to back out.